### PR TITLE
Doc: Fix opening documentation on F1

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,9 +1,11 @@
 Welcome to Orange3-Network's documentation!
 ===========================================
 
+Widgets
+-------
+
 .. toctree::
    :maxdepth: 1
-   :caption: Widgets
 
    widgets/networkfile
    widgets/networkexplorer


### PR DESCRIPTION
#### Issue
Documentation doesn't open when F1 is pressed.

#### Changes
Use title instead of caption so `Orange.canvas.help.provider.HtmlIndexProvider` will correctly parse documentation webpage.