### PR TITLE
[FIX] File: filename check

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+This is an issue template. Please fill in the relevant details in the
+sections below.
+-->
+
+##### Network version
+<!-- From menu _Options→Add-ons→Network_ -->
+
+
+##### Orange version
+<!-- From menu _Help→About→Version_ or code `Orange.version.full_version` -->
+
+
+##### Expected behavior
+
+
+
+##### Actual behavior
+
+
+
+##### Steps to reproduce the behavior
+
+
+
+##### Additional info (worksheets, data, screenshots, ...)
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+##### Issue
+<!-- E.g. Fixes #1, Implements #2, etc. -->
+<!-- Or a short description, if the issue does not exist. -->
+
+
+##### Description of changes
+
+
+##### Includes
+- [X] Code changes
+- [ ] Tests
+- [ ] Documentation

--- a/orangecontrib/network/widgets/OWNxFile.py
+++ b/orangecontrib/network/widgets/OWNxFile.py
@@ -237,7 +237,8 @@ class OWNxFile(OWWidget):
                        "GML files (*.gml)",
                        "All files (*)")))
 
-        if not filename: return
+        if not filename:
+            return
         try: self.recentFiles.remove(filename)
         except ValueError: pass
         self.recentFiles.insert(0, filename)
@@ -255,12 +256,13 @@ class OWNxFile(OWWidget):
                      path.dirname(self.recentFiles[0]) if self.recentFiles else
                      '.')
 
-        filename = QFileDialog.getOpenFileName(
+        filename, _ = QFileDialog.getOpenFileName(
             self, 'Open a Vertices Data File', startfile,
             'Data files (*.tab *.tsv *.csv);;'
             'All files(*)')
 
-        if not filename: return
+        if not filename:
+            return
         try: self.recentDataFiles.remove(filename)
         except ValueError: pass
         self.recentDataFiles.insert(0, filename)


### PR DESCRIPTION
Checking if `QFileDialog` returns `filename` sometimes causes an exception somewhere in the code.

Also add issue and pull request templates.