### PR TITLE
[FIX] Network Explorer: do not fail on a graph without domain

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -487,7 +487,8 @@ class OWNxExplorer(widget.OWWidget):
         self.edgesPerVertex = self.graph.number_of_edges() / max(1, self.graph.number_of_nodes())
 
         self._set_combos()
-        self.openContext(self.graph.items().domain)
+        if self.graph.items():
+            self.openContext(self.graph.items().domain)
         self.Error.clear()
 
         self.set_selection_mode()

--- a/orangecontrib/network/widgets/graphview.py
+++ b/orangecontrib/network/widgets/graphview.py
@@ -419,6 +419,7 @@ class GraphView(QGraphicsView):
         class AnimationThread(Thread):
             def __init__(self, iterations, callback):
                 super().__init__()
+                self.daemon = True
                 self.iterations = iterations
                 self.callback = callback
             def run(self):

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -1,0 +1,22 @@
+import networkx as nx
+
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.network.widgets.OWNxExplorer import OWNxExplorer
+from orangecontrib.network import readwrite
+
+
+class TestOWGradientDescent(WidgetTest):
+
+    def setUp(self):
+        self.widget = self.create_widget(OWNxExplorer)  # type: OWNxExplorer
+
+    def test_send_network_no_domain(self):
+        """
+        Some networks do not have a domain.
+        GH-59
+        """
+        w = self.widget
+        func = lambda n: nx.barbell_graph(int(n * .4), int(n * .3))
+        graph = readwrite._wrap(func(5))
+        self.send_signal(w.Inputs.network, graph)


### PR DESCRIPTION
##### Issue
Connect **Network Generator** and **Network Explorer**. The latter fails because it cannot open context since this graph does not have a `Domain` (nor `Table`).

##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
