### PR TITLE
[ENH] Network Explorer: change mouse cursor

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from AnyQt.QtCore import QTimer, QSize, Qt, QItemSelection, QItemSelectionRange
 from AnyQt.QtGui import QBrush, QColor
-from AnyQt.QtWidgets import QWidget, QListWidget, QFileDialog
+from AnyQt.QtWidgets import QListWidget, QFileDialog
 
 import Orange
 from Orange.util import scale
@@ -699,10 +699,6 @@ if __name__ == "__main__":
     owFile = OWNxFile.OWNxFile()
     owFile.Outputs.network.send = set_network
     owFile.openNetFile(join(dirname(dirname(__file__)), 'networks', 'leu_by_genesets.net'))
-    #~ owFile.openFile(join(dirname(dirname(__file__)), 'networks', 'airtraffic.net'))
-    #~ owFile.openFile(join(dirname(dirname(__file__)), 'networks', 'lastfm.net'))
-    #~ owFile.show()
-    #~ owFile.selectNetFile(0)
 
     a.exec_()
     ow.saveSettings()

--- a/orangecontrib/network/widgets/graphview.py
+++ b/orangecontrib/network/widgets/graphview.py
@@ -188,6 +188,7 @@ class Node(QGraphicsNode):
 
     def isHighlighted(self):
         return self._is_highlighted
+
     def setHighlighted(self, highlight):
         self._is_highlighted = highlight
         if not self.isSelected():
@@ -207,8 +208,10 @@ class Node(QGraphicsNode):
     def setTooltip(self, callback):
         assert not callback or callable(callback)
         self._tooltip = callback or Node._TOOLTIP
+
     def hoverEnterEvent(self, event):
         self.setToolTip(self._tooltip())
+
     def hoverLeaveEvent(self, event):
         self.setToolTip('');
 
@@ -288,10 +291,12 @@ class GraphView(QGraphicsView):
         super().mousePressEvent(event)
         # Reselect the selection that had just been discarded
         for node in self._selection: node.setSelected(True)
+
     def mouseMoveEvent(self, event):
         super().mouseMoveEvent(event)
         if not self._clicked_node:
             for node in self._selection: node.setSelected(True)
+
     def mouseReleaseEvent(self, event):
         super().mouseReleaseEvent(event)
         if self.dragMode() == self.RubberBandDrag:
@@ -312,10 +317,12 @@ class GraphView(QGraphicsView):
         text.setTextOption(option)
         scene = self.scene()
         scene.invalidate(layers=scene.BackgroundLayer)
+
     def drawForeground(self, painter, rect):
         painter.resetTransform()
         painter.drawStaticText(10, 10, self._text)
         super().drawForeground(painter, rect)
+
     def scrollContentsBy(self, dx, dy):
         scene = self.scene()
         scene.invalidate(layers=scene.BackgroundLayer)
@@ -331,17 +338,22 @@ class GraphView(QGraphicsView):
             for node in self.nodes:
                 getattr(node, state_setter)(node.id in nodes)
         self.selectionChanged.emit()
+
     def getSelected(self):
         return [node.id for node in self.scene().selectedItems()]
+
     def getUnselected(self):
         return [node.id
                 for node in (set(self.scene().items()) - set(self.scene().selectedItems()))
                 if isinstance(node, Node)]
+
     def setSelected(self, nodes, extend=False):
         self._setState(nodes, extend, 'setSelected')
+
     def getHighlighted(self):
         return [node.id for node in self.nodes
                 if node.isHighlighted() and not node.isSelected()]
+
     def setHighlighted(self, nodes):
         self._setState(nodes, False, 'setHighlighted')
 
@@ -390,6 +402,7 @@ class GraphView(QGraphicsView):
     def wheelEvent(self, event):
         if event.angleDelta().x() != 0: return
         self.scaleView(2**(event.angleDelta().y() / 240))
+
     def scaleView(self, factor):
         magnitude = self.transform().scale(factor, factor).mapRect(QRectF(0, 0, 1, 1)).width()
         if 0.2 < magnitude < 30:
@@ -402,10 +415,12 @@ class GraphView(QGraphicsView):
     @property
     def is_animating(self):
         return self._is_animating
+
     @is_animating.setter
     def is_animating(self, value):
         self.setCursor(Qt.ForbiddenCursor if value else Qt.ArrowCursor)
         self._is_animating = value
+
     def relayout(self, randomize=True, weight=None):
         if self.is_animating: return
         self.is_animating = True
@@ -442,7 +457,8 @@ class GraphView(QGraphicsView):
     def update_positions(self, positions, progress=1.0):
         self.positionsChanged.emit(positions, progress)
         return self._is_animating
-    def _update_positions(self, positions, progress):
+
+    def _update_positions(self, positions, _):
         for node, pos in zip(self.nodes, positions*300):
             node.setPos(*pos)
         qApp.processEvents()

--- a/orangecontrib/network/widgets/graphview.py
+++ b/orangecontrib/network/widgets/graphview.py
@@ -233,6 +233,7 @@ class GraphView(QGraphicsView):
         self._clicked_node = None
         self.is_animating = False
         self.legend = None
+        self._pressed = False
 
         scene = QGraphicsScene(self)
         scene.setItemIndexMethod(scene.BspTreeIndex)
@@ -276,6 +277,9 @@ class GraphView(QGraphicsView):
                 return
             # Save the current selection and restore it on mouse{Move,Release}
             self._clicked_node = self.itemAt(event.pos())
+            self._pressed = True
+            if self._clicked_node:
+                self.setCursor(Qt.ClosedHandCursor)
             if event.modifiers() & Qt.ShiftModifier:
                 self._selection = self.scene().selectedItems()
         # On right mouse button, switch to pan mode
@@ -296,14 +300,18 @@ class GraphView(QGraphicsView):
         super().mouseMoveEvent(event)
         if not self._clicked_node:
             for node in self._selection: node.setSelected(True)
+        if not self._pressed:
+            self.setCursor(Qt.OpenHandCursor if self.itemAt(event.pos()) else Qt.ArrowCursor)
 
     def mouseReleaseEvent(self, event):
         super().mouseReleaseEvent(event)
+        self._pressed = False
         if self.dragMode() == self.RubberBandDrag:
             for node in self._selection: node.setSelected(True)
             self.selectionChanged.emit()
         if self._clicked_node:
             self.selectionChanged.emit()
+            self.setCursor(Qt.OpenHandCursor)
         # The following line is required (QTBUG-48443)
         self.setDragMode(self.NoDrag)
         # Restore default drag mode


### PR DESCRIPTION
##### Issue
Only arrow is shown and therefore a user does not know that is over a node, etc.


##### Description of changes
Mouse cursor changes when moving nodes around or when hovering above the node. Something similar like in **Radviz** and **FreeViz** widgets.

Also some code cleaning.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
