### PR TITLE
[FIX] Network Explorer: widget windows size

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -263,6 +263,9 @@ class OWNxExplorer(widget.OWWidget):
         self.set_graph(None)
         self.set_selection_mode()
 
+    def sizeHint(self):
+        return QSize(800, 600)
+
     def commit(self):
         self.send_data()
 


### PR DESCRIPTION
##### Issue
Widget window size is too wide and this is caused by
```python
self.setSceneRect(-1e5, -1e5, 2e5, 2e5)
```
in file `graphview.py` (see: https://github.com/biolab/orange3-network/blob/4a5d6d2de816d73fc3d14540fbc3538b25caeeaa/orangecontrib/network/widgets/graphview.py#L238).

However this line is needed.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
