### PR TITLE
[ENH] Network Generator: new algorithm balanced tree

### DIFF
--- a/orangecontrib/network/widgets/OWNxGenerator.py
+++ b/orangecontrib/network/widgets/OWNxGenerator.py
@@ -13,9 +13,35 @@ import orangecontrib.network as network
 
 
 def _balanced_tree(n):
-    b = max(np.log(n) / 2, 2)
-    h = np.log((n * (b - 1)) + 1)/np.log(b) - 1
-    return nx.balanced_tree(int(b), int(h))
+    """
+    This function generates a balanced tree with approximately n nodes.
+    Each node of this tree has r children. Number of nodes cannot
+    be equal to n because real number of nodes is a sum of series
+    1 + r + r^2 + ... + r^h and we do not want to generate a trivial network
+    with one node and its n-1 children. Therefore this algorithm
+    finds a closest possible match. Number of children is also determined
+    by a logarithmic cost function.
+
+    Args:
+        n (int): number of nodes
+
+    Returns:
+        network x graph
+    """
+    series = lambda r, h: sum([r**x for x in range(h + 1)])
+    h, r = 1, 2
+    off = n
+    for r_ in range(2, 10):
+        last = series(r_, h)
+        for h_ in range(1, 15):
+            new = series(r_, h_)
+            if abs(new - n) * np.log2(r_) < off:
+                off = abs(new - n)
+                r, h = r_, h_
+            if abs(n - new) > abs(n - last):
+                break
+            last = new
+    return nx.balanced_tree(int(r), int(h))
 
 
 def _hypercube(n):

--- a/orangecontrib/network/widgets/tests/test_OWNxGenerator.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxGenerator.py
@@ -1,0 +1,19 @@
+from networkx.classes.graph import Graph
+
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.network.widgets.OWNxGenerator import OWNxGenerator, _balanced_tree
+
+
+class TestOWNxGenerator(WidgetTest):
+
+    def setUp(self):
+        self.widget = self.create_widget(OWNxGenerator)  # type: OWNxGenerator
+
+    def test_balanced_tree(self):
+        """
+        Does new balanced tree work?
+        GH-65
+        """
+        balanced_tree = _balanced_tree(100)
+        self.assertIsInstance(balanced_tree, Graph)


### PR DESCRIPTION
##### Issue
Current algorithm which creates _balanced tree_ is fast but not very accurate.

For a given number of nodes it creates a tree which has very different number of nodes. In the range from `5` to `10000` the error varies up to `88%` and the average error is about `7.5%`.

##### Description of changes
The new algorithm has an average error about `0.65%` and maximum `33.5%`.

This algorithm is not yet optimized and is written in a non pythonic way.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
