### PR TITLE
[FIX] Generator: output signal replace old signal name

### DIFF
--- a/orangecontrib/network/widgets/OWNxGenerator.py
+++ b/orangecontrib/network/widgets/OWNxGenerator.py
@@ -87,7 +87,7 @@ class OWNxGenerator(widget.OWWidget):
     priority = 6420
 
     class Outputs:
-        network = Output("Network", network.Graph)
+        network = Output("Network", network.Graph, replaces=["Generated network"])
 
     graph_type = settings.Setting(0)
     n_nodes = settings.Setting(50)


### PR DESCRIPTION
##### Issue
**Network Generator** widget got a different signal name but the back compatibility was not set.


##### Description of changes
Argument `replaces` fixes this problem.

~**Test will be added when #65 is merged.**~

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
