### PR TITLE
[FIX] Network Explorer: do not crash on selecting nodes when no items

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -512,6 +512,10 @@ class OWNxExplorer(widget.OWWidget):
 
         self.Warning.clear()
 
+        if self.selectionMode == SelectionMode.FROM_INPUT and \
+                (items is None or self.graph is None or self.graph.items() is None):
+            self.selectionMode = SelectionMode.NONE
+
         if items is None:
             self.view.selectionChanged.emit()
             return

--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -1,6 +1,5 @@
 import os
 from functools import wraps
-from itertools import chain
 from threading import Lock
 from xml.sax.saxutils import escape
 
@@ -521,15 +520,7 @@ class OWNxExplorer(widget.OWWidget):
             self.Warning.no_graph_or_items()
             return
 
-        graph_items = self.graph.items()
-        domain = graph_items.domain
-
         if len(items) > 0:
-            commonVars = (set(x.name for x in chain(items.domain.variables,
-                                                    items.domain.metas))
-                          & set(x.name for x in chain(domain.variables,
-                                                      domain.metas)))
-
             self.markInputRadioButton.setEnabled(True)
         self.view.selectionChanged.emit()
 

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -1,25 +1,38 @@
 import networkx as nx
 
+from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest
 
 from orangecontrib.network.widgets.OWNxExplorer import OWNxExplorer
 from orangecontrib.network import readwrite
 
 
-class TestOWGradientDescent(WidgetTest):
+class TestOWNxExplorer(WidgetTest):
 
     def setUp(self):
         self.widget = self.create_widget(OWNxExplorer)  # type: OWNxExplorer
+
+    def _create_graph(self):
+        func = lambda n: nx.barbell_graph(int(n * .4), int(n * .3))
+        return readwrite._wrap(func(5))
 
     def test_send_network_no_domain(self):
         """
         Some networks do not have a domain.
         GH-59
         """
+        self.send_signal(self.widget.Inputs.network, self._create_graph())
+
+    def test_select_nodes(self):
+        """
+        Do not fail on a wrong subset data and a graph without items.
+        GH-67
+        """
         w = self.widget
-        func = lambda n: nx.barbell_graph(int(n * .4), int(n * .3))
-        graph = readwrite._wrap(func(5))
-        self.send_signal(w.Inputs.network, graph)
+        self.send_signal(w.Inputs.network, self._create_graph())
+        table = Table("iris")
+        self.send_signal(w.Inputs.node_subset, table)
+        w.set_selection_mode()
 
     def test_show_edge_weights(self):
         """


### PR DESCRIPTION
##### Issue
See screenshot below. Notice that data from **File** widget are sent as _Node Subset_.

Then select nodes in **Network Explorer**. Widget crashes.

![screenshot_20180115_083554](https://user-images.githubusercontent.com/22157215/34931485-5d7caa96-f9cf-11e7-9eed-81cd4d494323.png)



##### Description of changes
_... from Node Subset input signal_ is not selected in second tab (_Marking_) when there is no proper subset data.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
