### PR TITLE
[FIX] Network Explorer: do not fail on no graph and one clicks

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -577,6 +577,8 @@ class OWNxExplorer(widget.OWWidget):
                 node.setTooltip(None)
 
     def set_edge_labels(self):
+        if not self.graph:
+            return
         if self.showEdgeWeights:
             weights = (str(w or '') for u, v, w in self.graph.edges(data='weight'))
         else:

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -20,3 +20,11 @@ class TestOWGradientDescent(WidgetTest):
         func = lambda n: nx.barbell_graph(int(n * .4), int(n * .3))
         graph = readwrite._wrap(func(5))
         self.send_signal(w.Inputs.network, graph)
+
+    def test_show_edge_weights(self):
+        """
+        Do not crash when there is no graph and
+        one click on Show edge weights.
+        GH-68
+        """
+        self.widget.checkbox_show_weights.click()


### PR DESCRIPTION
##### Issue
Open **Network Explorer** and click _Show edge weights_.

##### Description of changes


##### Includes
- [ ] Code changes
- [x] Tests
- [ ] Documentation
