### PR TITLE
[FIX] Network Generator: regular graph: degree less than nodes

### DIFF
--- a/orangecontrib/network/widgets/OWNxGenerator.py
+++ b/orangecontrib/network/widgets/OWNxGenerator.py
@@ -66,7 +66,7 @@ class GraphType:
     LOBSTER = ('Lobster', lambda n: nx.random_lobster(int(n / (1 + .7 + .7*.5)), .7, .5))
     LOLLIPOP = ('Lollipop', lambda n: nx.lollipop_graph(int(n/2), int(n/2)))
     PATH = ('Path', lambda n: nx.path_graph(int(n)))
-    REGULAR = ('Regular', lambda n: nx.random_regular_graph(np.random.randint(10)*2, n))
+    REGULAR = ('Regular', lambda n: nx.random_regular_graph(min(np.random.randint(10)*2, n - 1), n))
     SCALEFREE = ('Scale-free', lambda n: nx.scale_free_graph(int(n)))
     SHELL = ('Shell', lambda n: nx.random_shell_graph([(int(n*.1), int(n*.1), .2),
                                                        (int(n*.3), int(n*.3), .8),

--- a/orangecontrib/network/widgets/tests/test_OWNxGenerator.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxGenerator.py
@@ -2,7 +2,7 @@ from networkx.classes.graph import Graph
 
 from Orange.widgets.tests.base import WidgetTest
 
-from orangecontrib.network.widgets.OWNxGenerator import OWNxGenerator, _balanced_tree
+from orangecontrib.network.widgets.OWNxGenerator import OWNxGenerator, _balanced_tree, GraphType
 
 
 class TestOWNxGenerator(WidgetTest):
@@ -17,3 +17,17 @@ class TestOWNxGenerator(WidgetTest):
         """
         balanced_tree = _balanced_tree(100)
         self.assertIsInstance(balanced_tree, Graph)
+
+    def test_regular_graph(self):
+        """
+        Random regular graph: inequality 0 <= d < n must be
+        satisfied where d is degree of each node and n is
+        the number of nodes.
+        GH-69
+        """
+        w = self.widget
+        w.controls.graph_type.setCurrentIndex(GraphType.all.index(GraphType.REGULAR))
+        self.assertEqual(GraphType.all[w.controls.graph_type.currentIndex()][0], "Regular")
+        w.graph_type = 12
+        w.n_nodes = 1
+        w.commit()


### PR DESCRIPTION
##### Issue
Sometimes one selects low number of nodes and higher degree is generated by random generator. That causes widget **Network Generator** to fail.

##### Description of changes
Number of degree is corrected if higher than or equal number of nodes. Note that test still passes 10% of a time without a fix.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
