### PR TITLE
[ENH] OWNxExplorer: Re-layout randomization

### DIFF
--- a/orangecontrib/network/_fr_layout.cpp
+++ b/orangecontrib/network/_fr_layout.cpp
@@ -471,19 +471,33 @@
   #endif
 #endif
 
+#ifndef __cplusplus
+  #error "Cython files generated with the C++ option must be compiled with a C++ compiler."
+#endif
 #ifndef CYTHON_INLINE
   #if defined(__clang__)
     #define CYTHON_INLINE __inline__ __attribute__ ((__unused__))
-  #elif defined(__GNUC__)
-    #define CYTHON_INLINE __inline__
-  #elif defined(_MSC_VER)
-    #define CYTHON_INLINE __inline
-  #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    #define CYTHON_INLINE inline
   #else
-    #define CYTHON_INLINE
+    #define CYTHON_INLINE inline
   #endif
 #endif
+template<typename T>
+void __Pyx_call_destructor(T& x) {
+    x.~T();
+}
+template<typename T>
+class __Pyx_FakeReference {
+  public:
+    __Pyx_FakeReference() : ptr(NULL) { }
+    __Pyx_FakeReference(const T& ref) : ptr(const_cast<T*>(&ref)) { }
+    T *operator->() { return ptr; }
+    T *operator&() { return ptr; }
+    operator T&() { return *ptr; }
+    template<typename U> bool operator ==(U other) { return *ptr == other; }
+    template<typename U> bool operator !=(U other) { return *ptr != other; }
+  private:
+    T *ptr;
+};
 
 #if defined(WIN32) || defined(MS_WINDOWS)
   #define _USE_MATH_DEFINES
@@ -867,7 +881,7 @@ typedef struct {
 } __Pyx_BufFmt_Context;
 
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":743
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":743
  * # in Cython to enable them only on the right systems.
  * 
  * ctypedef npy_int8       int8_t             # <<<<<<<<<<<<<<
@@ -876,7 +890,7 @@ typedef struct {
  */
 typedef npy_int8 __pyx_t_5numpy_int8_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":744
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":744
  * 
  * ctypedef npy_int8       int8_t
  * ctypedef npy_int16      int16_t             # <<<<<<<<<<<<<<
@@ -885,7 +899,7 @@ typedef npy_int8 __pyx_t_5numpy_int8_t;
  */
 typedef npy_int16 __pyx_t_5numpy_int16_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":745
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":745
  * ctypedef npy_int8       int8_t
  * ctypedef npy_int16      int16_t
  * ctypedef npy_int32      int32_t             # <<<<<<<<<<<<<<
@@ -894,7 +908,7 @@ typedef npy_int16 __pyx_t_5numpy_int16_t;
  */
 typedef npy_int32 __pyx_t_5numpy_int32_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":746
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":746
  * ctypedef npy_int16      int16_t
  * ctypedef npy_int32      int32_t
  * ctypedef npy_int64      int64_t             # <<<<<<<<<<<<<<
@@ -903,7 +917,7 @@ typedef npy_int32 __pyx_t_5numpy_int32_t;
  */
 typedef npy_int64 __pyx_t_5numpy_int64_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":750
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":750
  * #ctypedef npy_int128     int128_t
  * 
  * ctypedef npy_uint8      uint8_t             # <<<<<<<<<<<<<<
@@ -912,7 +926,7 @@ typedef npy_int64 __pyx_t_5numpy_int64_t;
  */
 typedef npy_uint8 __pyx_t_5numpy_uint8_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":751
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":751
  * 
  * ctypedef npy_uint8      uint8_t
  * ctypedef npy_uint16     uint16_t             # <<<<<<<<<<<<<<
@@ -921,7 +935,7 @@ typedef npy_uint8 __pyx_t_5numpy_uint8_t;
  */
 typedef npy_uint16 __pyx_t_5numpy_uint16_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":752
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":752
  * ctypedef npy_uint8      uint8_t
  * ctypedef npy_uint16     uint16_t
  * ctypedef npy_uint32     uint32_t             # <<<<<<<<<<<<<<
@@ -930,7 +944,7 @@ typedef npy_uint16 __pyx_t_5numpy_uint16_t;
  */
 typedef npy_uint32 __pyx_t_5numpy_uint32_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":753
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":753
  * ctypedef npy_uint16     uint16_t
  * ctypedef npy_uint32     uint32_t
  * ctypedef npy_uint64     uint64_t             # <<<<<<<<<<<<<<
@@ -939,7 +953,7 @@ typedef npy_uint32 __pyx_t_5numpy_uint32_t;
  */
 typedef npy_uint64 __pyx_t_5numpy_uint64_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":757
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":757
  * #ctypedef npy_uint128    uint128_t
  * 
  * ctypedef npy_float32    float32_t             # <<<<<<<<<<<<<<
@@ -948,7 +962,7 @@ typedef npy_uint64 __pyx_t_5numpy_uint64_t;
  */
 typedef npy_float32 __pyx_t_5numpy_float32_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":758
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":758
  * 
  * ctypedef npy_float32    float32_t
  * ctypedef npy_float64    float64_t             # <<<<<<<<<<<<<<
@@ -957,7 +971,7 @@ typedef npy_float32 __pyx_t_5numpy_float32_t;
  */
 typedef npy_float64 __pyx_t_5numpy_float64_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":767
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":767
  * # The int types are mapped a bit surprising --
  * # numpy.int corresponds to 'l' and numpy.long to 'q'
  * ctypedef npy_long       int_t             # <<<<<<<<<<<<<<
@@ -966,7 +980,7 @@ typedef npy_float64 __pyx_t_5numpy_float64_t;
  */
 typedef npy_long __pyx_t_5numpy_int_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":768
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":768
  * # numpy.int corresponds to 'l' and numpy.long to 'q'
  * ctypedef npy_long       int_t
  * ctypedef npy_longlong   long_t             # <<<<<<<<<<<<<<
@@ -975,7 +989,7 @@ typedef npy_long __pyx_t_5numpy_int_t;
  */
 typedef npy_longlong __pyx_t_5numpy_long_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":769
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":769
  * ctypedef npy_long       int_t
  * ctypedef npy_longlong   long_t
  * ctypedef npy_longlong   longlong_t             # <<<<<<<<<<<<<<
@@ -984,7 +998,7 @@ typedef npy_longlong __pyx_t_5numpy_long_t;
  */
 typedef npy_longlong __pyx_t_5numpy_longlong_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":771
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":771
  * ctypedef npy_longlong   longlong_t
  * 
  * ctypedef npy_ulong      uint_t             # <<<<<<<<<<<<<<
@@ -993,7 +1007,7 @@ typedef npy_longlong __pyx_t_5numpy_longlong_t;
  */
 typedef npy_ulong __pyx_t_5numpy_uint_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":772
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":772
  * 
  * ctypedef npy_ulong      uint_t
  * ctypedef npy_ulonglong  ulong_t             # <<<<<<<<<<<<<<
@@ -1002,7 +1016,7 @@ typedef npy_ulong __pyx_t_5numpy_uint_t;
  */
 typedef npy_ulonglong __pyx_t_5numpy_ulong_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":773
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":773
  * ctypedef npy_ulong      uint_t
  * ctypedef npy_ulonglong  ulong_t
  * ctypedef npy_ulonglong  ulonglong_t             # <<<<<<<<<<<<<<
@@ -1011,7 +1025,7 @@ typedef npy_ulonglong __pyx_t_5numpy_ulong_t;
  */
 typedef npy_ulonglong __pyx_t_5numpy_ulonglong_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":775
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":775
  * ctypedef npy_ulonglong  ulonglong_t
  * 
  * ctypedef npy_intp       intp_t             # <<<<<<<<<<<<<<
@@ -1020,7 +1034,7 @@ typedef npy_ulonglong __pyx_t_5numpy_ulonglong_t;
  */
 typedef npy_intp __pyx_t_5numpy_intp_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":776
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":776
  * 
  * ctypedef npy_intp       intp_t
  * ctypedef npy_uintp      uintp_t             # <<<<<<<<<<<<<<
@@ -1029,7 +1043,7 @@ typedef npy_intp __pyx_t_5numpy_intp_t;
  */
 typedef npy_uintp __pyx_t_5numpy_uintp_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":778
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":778
  * ctypedef npy_uintp      uintp_t
  * 
  * ctypedef npy_double     float_t             # <<<<<<<<<<<<<<
@@ -1038,7 +1052,7 @@ typedef npy_uintp __pyx_t_5numpy_uintp_t;
  */
 typedef npy_double __pyx_t_5numpy_float_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":779
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":779
  * 
  * ctypedef npy_double     float_t
  * ctypedef npy_double     double_t             # <<<<<<<<<<<<<<
@@ -1047,7 +1061,7 @@ typedef npy_double __pyx_t_5numpy_float_t;
  */
 typedef npy_double __pyx_t_5numpy_double_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":780
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":780
  * ctypedef npy_double     float_t
  * ctypedef npy_double     double_t
  * ctypedef npy_longdouble longdouble_t             # <<<<<<<<<<<<<<
@@ -1095,7 +1109,7 @@ struct __pyx_MemviewEnum_obj;
 struct __pyx_memoryview_obj;
 struct __pyx_memoryviewslice_obj;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":782
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":782
  * ctypedef npy_longdouble longdouble_t
  * 
  * ctypedef npy_cfloat      cfloat_t             # <<<<<<<<<<<<<<
@@ -1104,7 +1118,7 @@ struct __pyx_memoryviewslice_obj;
  */
 typedef npy_cfloat __pyx_t_5numpy_cfloat_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":783
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":783
  * 
  * ctypedef npy_cfloat      cfloat_t
  * ctypedef npy_cdouble     cdouble_t             # <<<<<<<<<<<<<<
@@ -1113,7 +1127,7 @@ typedef npy_cfloat __pyx_t_5numpy_cfloat_t;
  */
 typedef npy_cdouble __pyx_t_5numpy_cdouble_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":784
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":784
  * ctypedef npy_cfloat      cfloat_t
  * ctypedef npy_cdouble     cdouble_t
  * ctypedef npy_clongdouble clongdouble_t             # <<<<<<<<<<<<<<
@@ -1122,7 +1136,7 @@ typedef npy_cdouble __pyx_t_5numpy_cdouble_t;
  */
 typedef npy_clongdouble __pyx_t_5numpy_clongdouble_t;
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":786
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":786
  * ctypedef npy_clongdouble clongdouble_t
  * 
  * ctypedef npy_cdouble     complex_t             # <<<<<<<<<<<<<<
@@ -2414,10 +2428,10 @@ static PyObject *__pyx_tp_new_array(PyTypeObject *t, PyObject *a, PyObject *k); 
 static PyObject *__pyx_tp_new_Enum(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
 static PyObject *__pyx_tp_new_memoryview(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
 static PyObject *__pyx_tp_new__memoryviewslice(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
-static PyObject *__pyx_float__4;
 static PyObject *__pyx_float__5;
 static PyObject *__pyx_float__05;
 static PyObject *__pyx_float_0_1;
+static PyObject *__pyx_float__001;
 static PyObject *__pyx_float_0_25;
 static PyObject *__pyx_int_0;
 static PyObject *__pyx_int_1;
@@ -4805,7 +4819,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
   long __pyx_t_10;
   Py_ssize_t __pyx_t_11;
   __pyx_t_13orangecontrib_7network_10_fr_layout_arr_i1_t __pyx_t_12 = { 0, 0, { 0 }, { 0 }, { 0 } };
-  __Pyx_memviewslice __pyx_t_13 = { 0, 0, { 0 }, { 0 }, { 0 } };
+  Py_ssize_t __pyx_t_13;
   Py_ssize_t __pyx_t_14;
   Py_ssize_t __pyx_t_15;
   Py_ssize_t __pyx_t_16;
@@ -4820,12 +4834,12 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
   Py_ssize_t __pyx_t_25;
   Py_ssize_t __pyx_t_26;
   Py_ssize_t __pyx_t_27;
-  Py_ssize_t __pyx_t_28;
-  __pyx_t_5numpy_int32_t __pyx_t_29;
-  Py_ssize_t __pyx_t_30;
-  __pyx_t_5numpy_int32_t __pyx_t_31;
-  Py_ssize_t __pyx_t_32;
-  double __pyx_t_33;
+  __pyx_t_5numpy_int32_t __pyx_t_28;
+  Py_ssize_t __pyx_t_29;
+  __pyx_t_5numpy_int32_t __pyx_t_30;
+  Py_ssize_t __pyx_t_31;
+  double __pyx_t_32;
+  Py_ssize_t __pyx_t_33;
   Py_ssize_t __pyx_t_34;
   Py_ssize_t __pyx_t_35;
   Py_ssize_t __pyx_t_36;
@@ -4841,21 +4855,20 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
   Py_ssize_t __pyx_t_46;
   Py_ssize_t __pyx_t_47;
   Py_ssize_t __pyx_t_48;
-  Py_ssize_t __pyx_t_49;
+  double __pyx_t_49;
   double __pyx_t_50;
-  double __pyx_t_51;
+  Py_ssize_t __pyx_t_51;
   Py_ssize_t __pyx_t_52;
-  Py_ssize_t __pyx_t_53;
-  int __pyx_t_54;
-  PyObject *__pyx_t_55 = NULL;
-  int __pyx_t_56;
+  int __pyx_t_53;
+  PyObject *__pyx_t_54 = NULL;
+  int __pyx_t_55;
   __Pyx_RefNannySetupContext("_fruchterman_reingold", 0);
 
   /* "orangecontrib/network/_fr_layout.pyx":151
  *                                     double callback_rate):
  *     cdef:
  *         double GRAVITY = 20             # <<<<<<<<<<<<<<
- *         arr_f1_t temperature = np.linspace(.4, .05, iterations)
+ *         arr_f1_t temperature = np.linspace(.05, .001, iterations)
  *         arr_f2_t disp = np.empty((pos.shape[0], pos.shape[1]))
  */
   __pyx_v_GRAVITY = 20.0;
@@ -4863,7 +4876,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
   /* "orangecontrib/network/_fr_layout.pyx":152
  *     cdef:
  *         double GRAVITY = 20
- *         arr_f1_t temperature = np.linspace(.4, .05, iterations)             # <<<<<<<<<<<<<<
+ *         arr_f1_t temperature = np.linspace(.05, .001, iterations)             # <<<<<<<<<<<<<<
  *         arr_f2_t disp = np.empty((pos.shape[0], pos.shape[1]))
  *         arr_f1_t delta = np.empty(pos.shape[1])
  */
@@ -4888,7 +4901,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
   }
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
-    PyObject *__pyx_temp[4] = {__pyx_t_4, __pyx_float__4, __pyx_float__05, __pyx_t_2};
+    PyObject *__pyx_temp[4] = {__pyx_t_4, __pyx_float__05, __pyx_float__001, __pyx_t_2};
     __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_5, 3+__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 152, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_1);
@@ -4897,7 +4910,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
   #endif
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
-    PyObject *__pyx_temp[4] = {__pyx_t_4, __pyx_float__4, __pyx_float__05, __pyx_t_2};
+    PyObject *__pyx_temp[4] = {__pyx_t_4, __pyx_float__05, __pyx_float__001, __pyx_t_2};
     __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_5, 3+__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 152, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_1);
@@ -4910,12 +4923,12 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
     if (__pyx_t_4) {
       __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_4); __pyx_t_4 = NULL;
     }
-    __Pyx_INCREF(__pyx_float__4);
-    __Pyx_GIVEREF(__pyx_float__4);
-    PyTuple_SET_ITEM(__pyx_t_6, 0+__pyx_t_5, __pyx_float__4);
     __Pyx_INCREF(__pyx_float__05);
     __Pyx_GIVEREF(__pyx_float__05);
-    PyTuple_SET_ITEM(__pyx_t_6, 1+__pyx_t_5, __pyx_float__05);
+    PyTuple_SET_ITEM(__pyx_t_6, 0+__pyx_t_5, __pyx_float__05);
+    __Pyx_INCREF(__pyx_float__001);
+    __Pyx_GIVEREF(__pyx_float__001);
+    PyTuple_SET_ITEM(__pyx_t_6, 1+__pyx_t_5, __pyx_float__001);
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_6, 2+__pyx_t_5, __pyx_t_2);
     __pyx_t_2 = 0;
@@ -4933,7 +4946,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
 
   /* "orangecontrib/network/_fr_layout.pyx":153
  *         double GRAVITY = 20
- *         arr_f1_t temperature = np.linspace(.4, .05, iterations)
+ *         arr_f1_t temperature = np.linspace(.05, .001, iterations)
  *         arr_f2_t disp = np.empty((pos.shape[0], pos.shape[1]))             # <<<<<<<<<<<<<<
  *         arr_f1_t delta = np.empty(pos.shape[1])
  *         double mag, adj, weight, temp
@@ -5009,7 +5022,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
   __pyx_t_8.data = NULL;
 
   /* "orangecontrib/network/_fr_layout.pyx":154
- *         arr_f1_t temperature = np.linspace(.4, .05, iterations)
+ *         arr_f1_t temperature = np.linspace(.05, .001, iterations)
  *         arr_f2_t disp = np.empty((pos.shape[0], pos.shape[1]))
  *         arr_f1_t delta = np.empty(pos.shape[1])             # <<<<<<<<<<<<<<
  *         double mag, adj, weight, temp
@@ -5198,7 +5211,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  *         arr_i1_t sample = np.zeros(sample_size, dtype=np.int32)
  *         int callback_freq = int(round(1/callback_rate))             # <<<<<<<<<<<<<<
  *     with nogil:
- *         temperature[:6] = .8
+ *         for iteration in range(iterations):
  */
   __pyx_t_4 = PyFloat_FromDouble((1.0 / __pyx_v_callback_rate)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 163, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
@@ -5221,8 +5234,8 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  *         arr_i1_t sample = np.zeros(sample_size, dtype=np.int32)
  *         int callback_freq = int(round(1/callback_rate))
  *     with nogil:             # <<<<<<<<<<<<<<
- *         temperature[:6] = .8
  *         for iteration in range(iterations):
+ *             temp = temperature[iteration]
  */
   {
       #ifdef WITH_THREAD
@@ -5235,52 +5248,6 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
         /* "orangecontrib/network/_fr_layout.pyx":165
  *         int callback_freq = int(round(1/callback_rate))
  *     with nogil:
- *         temperature[:6] = .8             # <<<<<<<<<<<<<<
- *         for iteration in range(iterations):
- *             temp = temperature[iteration]
- */
-        __pyx_t_13.data = __pyx_v_temperature.data;
-        __pyx_t_13.memview = __pyx_v_temperature.memview;
-        __PYX_INC_MEMVIEW(&__pyx_t_13, 0);
-        __pyx_t_5 = -1;
-        if (unlikely(__pyx_memoryview_slice_memviewslice(
-    &__pyx_t_13,
-    __pyx_v_temperature.shape[0], __pyx_v_temperature.strides[0], __pyx_v_temperature.suboffsets[0],
-    0,
-    0,
-    &__pyx_t_5,
-    0,
-    6,
-    0,
-    0,
-    1,
-    0,
-    1) < 0))
-{
-    __PYX_ERR(0, 165, __pyx_L4_error)
-}
-
-{
-            double __pyx_temp_scalar = .8;
-            {
-                Py_ssize_t __pyx_temp_extent_0 = __pyx_t_13.shape[0];
-                Py_ssize_t __pyx_temp_stride_0 = __pyx_t_13.strides[0];
-                char *__pyx_temp_pointer_0;
-                Py_ssize_t __pyx_temp_idx_0;
-                __pyx_temp_pointer_0 = __pyx_t_13.data;
-                for (__pyx_temp_idx_0 = 0; __pyx_temp_idx_0 < __pyx_temp_extent_0; __pyx_temp_idx_0++) {
-                  *((double *) __pyx_temp_pointer_0) = __pyx_temp_scalar;
-                  __pyx_temp_pointer_0 += __pyx_temp_stride_0;
-                }
-            }
-        }
-        __PYX_XDEC_MEMVIEW(&__pyx_t_13, 0);
-        __pyx_t_13.memview = NULL;
-        __pyx_t_13.data = NULL;
-
-        /* "orangecontrib/network/_fr_layout.pyx":166
- *     with nogil:
- *         temperature[:6] = .8
  *         for iteration in range(iterations):             # <<<<<<<<<<<<<<
  *             temp = temperature[iteration]
  *             disp[:, :] = 0
@@ -5289,17 +5256,17 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
         for (__pyx_t_11 = 0; __pyx_t_11 < __pyx_t_5; __pyx_t_11+=1) {
           __pyx_v_iteration = __pyx_t_11;
 
-          /* "orangecontrib/network/_fr_layout.pyx":167
- *         temperature[:6] = .8
+          /* "orangecontrib/network/_fr_layout.pyx":166
+ *     with nogil:
  *         for iteration in range(iterations):
  *             temp = temperature[iteration]             # <<<<<<<<<<<<<<
  *             disp[:, :] = 0
  *             for i in range(sample_size):
  */
-          __pyx_t_14 = __pyx_v_iteration;
-          __pyx_v_temp = (*((double *) ( /* dim=0 */ (__pyx_v_temperature.data + __pyx_t_14 * __pyx_v_temperature.strides[0]) )));
+          __pyx_t_13 = __pyx_v_iteration;
+          __pyx_v_temp = (*((double *) ( /* dim=0 */ (__pyx_v_temperature.data + __pyx_t_13 * __pyx_v_temperature.strides[0]) )));
 
-          /* "orangecontrib/network/_fr_layout.pyx":168
+          /* "orangecontrib/network/_fr_layout.pyx":167
  *         for iteration in range(iterations):
  *             temp = temperature[iteration]
  *             disp[:, :] = 0             # <<<<<<<<<<<<<<
@@ -5329,61 +5296,61 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
               }
           }
 
-          /* "orangecontrib/network/_fr_layout.pyx":169
+          /* "orangecontrib/network/_fr_layout.pyx":168
  *             temp = temperature[iteration]
  *             disp[:, :] = 0
  *             for i in range(sample_size):             # <<<<<<<<<<<<<<
  *                 sample[i] = rand() % n_nodes
  *             # Repulsive forces
  */
-          __pyx_t_15 = __pyx_v_sample_size;
-          for (__pyx_t_16 = 0; __pyx_t_16 < __pyx_t_15; __pyx_t_16+=1) {
-            __pyx_v_i = __pyx_t_16;
+          __pyx_t_14 = __pyx_v_sample_size;
+          for (__pyx_t_15 = 0; __pyx_t_15 < __pyx_t_14; __pyx_t_15+=1) {
+            __pyx_v_i = __pyx_t_15;
 
-            /* "orangecontrib/network/_fr_layout.pyx":170
+            /* "orangecontrib/network/_fr_layout.pyx":169
  *             disp[:, :] = 0
  *             for i in range(sample_size):
  *                 sample[i] = rand() % n_nodes             # <<<<<<<<<<<<<<
  *             # Repulsive forces
  *             for i in range(n_nodes):
  */
-            __pyx_t_17 = __pyx_v_i;
-            *((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_sample.data + __pyx_t_17 * __pyx_v_sample.strides[0]) )) = (rand() % __pyx_v_n_nodes);
+            __pyx_t_16 = __pyx_v_i;
+            *((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_sample.data + __pyx_t_16 * __pyx_v_sample.strides[0]) )) = (rand() % __pyx_v_n_nodes);
           }
 
-          /* "orangecontrib/network/_fr_layout.pyx":172
+          /* "orangecontrib/network/_fr_layout.pyx":171
  *                 sample[i] = rand() % n_nodes
  *             # Repulsive forces
  *             for i in range(n_nodes):             # <<<<<<<<<<<<<<
  *                 for s in range(sample_size):
  *                     j = sample[s]
  */
-          __pyx_t_15 = __pyx_v_n_nodes;
-          for (__pyx_t_16 = 0; __pyx_t_16 < __pyx_t_15; __pyx_t_16+=1) {
-            __pyx_v_i = __pyx_t_16;
+          __pyx_t_14 = __pyx_v_n_nodes;
+          for (__pyx_t_15 = 0; __pyx_t_15 < __pyx_t_14; __pyx_t_15+=1) {
+            __pyx_v_i = __pyx_t_15;
 
-            /* "orangecontrib/network/_fr_layout.pyx":173
+            /* "orangecontrib/network/_fr_layout.pyx":172
  *             # Repulsive forces
  *             for i in range(n_nodes):
  *                 for s in range(sample_size):             # <<<<<<<<<<<<<<
  *                     j = sample[s]
  *                     diff(pos, i, j, delta)
  */
-            __pyx_t_18 = __pyx_v_sample_size;
-            for (__pyx_t_19 = 0; __pyx_t_19 < __pyx_t_18; __pyx_t_19+=1) {
-              __pyx_v_s = __pyx_t_19;
+            __pyx_t_17 = __pyx_v_sample_size;
+            for (__pyx_t_18 = 0; __pyx_t_18 < __pyx_t_17; __pyx_t_18+=1) {
+              __pyx_v_s = __pyx_t_18;
 
-              /* "orangecontrib/network/_fr_layout.pyx":174
+              /* "orangecontrib/network/_fr_layout.pyx":173
  *             for i in range(n_nodes):
  *                 for s in range(sample_size):
  *                     j = sample[s]             # <<<<<<<<<<<<<<
  *                     diff(pos, i, j, delta)
  *                     mag = magnitude(delta)
  */
-              __pyx_t_20 = __pyx_v_s;
-              __pyx_v_j = (*((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_sample.data + __pyx_t_20 * __pyx_v_sample.strides[0]) )));
+              __pyx_t_19 = __pyx_v_s;
+              __pyx_v_j = (*((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_sample.data + __pyx_t_19 * __pyx_v_sample.strides[0]) )));
 
-              /* "orangecontrib/network/_fr_layout.pyx":175
+              /* "orangecontrib/network/_fr_layout.pyx":174
  *                 for s in range(sample_size):
  *                     j = sample[s]
  *                     diff(pos, i, j, delta)             # <<<<<<<<<<<<<<
@@ -5392,7 +5359,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  */
               __pyx_f_13orangecontrib_7network_10_fr_layout_diff(__pyx_v_pos, __pyx_v_i, __pyx_v_j, __pyx_v_delta);
 
-              /* "orangecontrib/network/_fr_layout.pyx":176
+              /* "orangecontrib/network/_fr_layout.pyx":175
  *                     j = sample[s]
  *                     diff(pos, i, j, delta)
  *                     mag = magnitude(delta)             # <<<<<<<<<<<<<<
@@ -5401,7 +5368,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  */
               __pyx_v_mag = __pyx_f_13orangecontrib_7network_10_fr_layout_magnitude(__pyx_v_delta);
 
-              /* "orangecontrib/network/_fr_layout.pyx":177
+              /* "orangecontrib/network/_fr_layout.pyx":176
  *                     diff(pos, i, j, delta)
  *                     mag = magnitude(delta)
  *                     if mag == 0: continue             # <<<<<<<<<<<<<<
@@ -5413,85 +5380,85 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
                 goto __pyx_L12_continue;
               }
 
-              /* "orangecontrib/network/_fr_layout.pyx":178
+              /* "orangecontrib/network/_fr_layout.pyx":177
  *                     mag = magnitude(delta)
  *                     if mag == 0: continue
  *                     for d in range(n_dim):             # <<<<<<<<<<<<<<
  *                         disp[i, d] += delta[d] / mag * _Fr(k, mag)
  *                 for d in range(n_dim):
  */
-              __pyx_t_21 = __pyx_v_n_dim;
-              for (__pyx_t_22 = 0; __pyx_t_22 < __pyx_t_21; __pyx_t_22+=1) {
-                __pyx_v_d = __pyx_t_22;
+              __pyx_t_20 = __pyx_v_n_dim;
+              for (__pyx_t_21 = 0; __pyx_t_21 < __pyx_t_20; __pyx_t_21+=1) {
+                __pyx_v_d = __pyx_t_21;
 
-                /* "orangecontrib/network/_fr_layout.pyx":179
+                /* "orangecontrib/network/_fr_layout.pyx":178
  *                     if mag == 0: continue
  *                     for d in range(n_dim):
  *                         disp[i, d] += delta[d] / mag * _Fr(k, mag)             # <<<<<<<<<<<<<<
  *                 for d in range(n_dim):
  *                     disp[i,d] *= 1.0/sample_ratio
  */
-                __pyx_t_23 = __pyx_v_d;
-                __pyx_t_24 = __pyx_v_i;
-                __pyx_t_25 = __pyx_v_d;
-                *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_24 * __pyx_v_disp.strides[0]) ) + __pyx_t_25 * __pyx_v_disp.strides[1]) )) += (((*((double *) ( /* dim=0 */ (__pyx_v_delta.data + __pyx_t_23 * __pyx_v_delta.strides[0]) ))) / __pyx_v_mag) * __pyx_f_13orangecontrib_7network_10_fr_layout__Fr(__pyx_v_k, __pyx_v_mag));
+                __pyx_t_22 = __pyx_v_d;
+                __pyx_t_23 = __pyx_v_i;
+                __pyx_t_24 = __pyx_v_d;
+                *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_23 * __pyx_v_disp.strides[0]) ) + __pyx_t_24 * __pyx_v_disp.strides[1]) )) += (((*((double *) ( /* dim=0 */ (__pyx_v_delta.data + __pyx_t_22 * __pyx_v_delta.strides[0]) ))) / __pyx_v_mag) * __pyx_f_13orangecontrib_7network_10_fr_layout__Fr(__pyx_v_k, __pyx_v_mag));
               }
               __pyx_L12_continue:;
             }
 
-            /* "orangecontrib/network/_fr_layout.pyx":180
+            /* "orangecontrib/network/_fr_layout.pyx":179
  *                     for d in range(n_dim):
  *                         disp[i, d] += delta[d] / mag * _Fr(k, mag)
  *                 for d in range(n_dim):             # <<<<<<<<<<<<<<
  *                     disp[i,d] *= 1.0/sample_ratio
  *             # Attractive forces
  */
-            __pyx_t_18 = __pyx_v_n_dim;
-            for (__pyx_t_19 = 0; __pyx_t_19 < __pyx_t_18; __pyx_t_19+=1) {
-              __pyx_v_d = __pyx_t_19;
+            __pyx_t_17 = __pyx_v_n_dim;
+            for (__pyx_t_18 = 0; __pyx_t_18 < __pyx_t_17; __pyx_t_18+=1) {
+              __pyx_v_d = __pyx_t_18;
 
-              /* "orangecontrib/network/_fr_layout.pyx":181
+              /* "orangecontrib/network/_fr_layout.pyx":180
  *                         disp[i, d] += delta[d] / mag * _Fr(k, mag)
  *                 for d in range(n_dim):
  *                     disp[i,d] *= 1.0/sample_ratio             # <<<<<<<<<<<<<<
  *             # Attractive forces
  *             for i in range(n_edges):
  */
-              __pyx_t_26 = __pyx_v_i;
-              __pyx_t_27 = __pyx_v_d;
-              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_26 * __pyx_v_disp.strides[0]) ) + __pyx_t_27 * __pyx_v_disp.strides[1]) )) *= (1.0 / __pyx_v_sample_ratio);
+              __pyx_t_25 = __pyx_v_i;
+              __pyx_t_26 = __pyx_v_d;
+              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_25 * __pyx_v_disp.strides[0]) ) + __pyx_t_26 * __pyx_v_disp.strides[1]) )) *= (1.0 / __pyx_v_sample_ratio);
             }
           }
 
-          /* "orangecontrib/network/_fr_layout.pyx":183
+          /* "orangecontrib/network/_fr_layout.pyx":182
  *                     disp[i,d] *= 1.0/sample_ratio
  *             # Attractive forces
  *             for i in range(n_edges):             # <<<<<<<<<<<<<<
  *                 row, col, weight = Erow[i], Ecol[i], Edata[i]
  *                 diff(pos, row, col, delta)
  */
-          __pyx_t_15 = __pyx_v_n_edges;
-          for (__pyx_t_16 = 0; __pyx_t_16 < __pyx_t_15; __pyx_t_16+=1) {
-            __pyx_v_i = __pyx_t_16;
+          __pyx_t_14 = __pyx_v_n_edges;
+          for (__pyx_t_15 = 0; __pyx_t_15 < __pyx_t_14; __pyx_t_15+=1) {
+            __pyx_v_i = __pyx_t_15;
 
-            /* "orangecontrib/network/_fr_layout.pyx":184
+            /* "orangecontrib/network/_fr_layout.pyx":183
  *             # Attractive forces
  *             for i in range(n_edges):
  *                 row, col, weight = Erow[i], Ecol[i], Edata[i]             # <<<<<<<<<<<<<<
  *                 diff(pos, row, col, delta)
  *                 mag = magnitude(delta)
  */
-            __pyx_t_28 = __pyx_v_i;
-            __pyx_t_29 = (*((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_Erow.data + __pyx_t_28 * __pyx_v_Erow.strides[0]) )));
-            __pyx_t_30 = __pyx_v_i;
-            __pyx_t_31 = (*((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_Ecol.data + __pyx_t_30 * __pyx_v_Ecol.strides[0]) )));
-            __pyx_t_32 = __pyx_v_i;
-            __pyx_t_33 = (*((double *) ( /* dim=0 */ (__pyx_v_Edata.data + __pyx_t_32 * __pyx_v_Edata.strides[0]) )));
-            __pyx_v_row = __pyx_t_29;
-            __pyx_v_col = __pyx_t_31;
-            __pyx_v_weight = __pyx_t_33;
+            __pyx_t_27 = __pyx_v_i;
+            __pyx_t_28 = (*((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_Erow.data + __pyx_t_27 * __pyx_v_Erow.strides[0]) )));
+            __pyx_t_29 = __pyx_v_i;
+            __pyx_t_30 = (*((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_Ecol.data + __pyx_t_29 * __pyx_v_Ecol.strides[0]) )));
+            __pyx_t_31 = __pyx_v_i;
+            __pyx_t_32 = (*((double *) ( /* dim=0 */ (__pyx_v_Edata.data + __pyx_t_31 * __pyx_v_Edata.strides[0]) )));
+            __pyx_v_row = __pyx_t_28;
+            __pyx_v_col = __pyx_t_30;
+            __pyx_v_weight = __pyx_t_32;
 
-            /* "orangecontrib/network/_fr_layout.pyx":185
+            /* "orangecontrib/network/_fr_layout.pyx":184
  *             for i in range(n_edges):
  *                 row, col, weight = Erow[i], Ecol[i], Edata[i]
  *                 diff(pos, row, col, delta)             # <<<<<<<<<<<<<<
@@ -5500,7 +5467,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  */
             __pyx_f_13orangecontrib_7network_10_fr_layout_diff(__pyx_v_pos, __pyx_v_row, __pyx_v_col, __pyx_v_delta);
 
-            /* "orangecontrib/network/_fr_layout.pyx":186
+            /* "orangecontrib/network/_fr_layout.pyx":185
  *                 row, col, weight = Erow[i], Ecol[i], Edata[i]
  *                 diff(pos, row, col, delta)
  *                 mag = magnitude(delta)             # <<<<<<<<<<<<<<
@@ -5509,7 +5476,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  */
             __pyx_v_mag = __pyx_f_13orangecontrib_7network_10_fr_layout_magnitude(__pyx_v_delta);
 
-            /* "orangecontrib/network/_fr_layout.pyx":187
+            /* "orangecontrib/network/_fr_layout.pyx":186
  *                 diff(pos, row, col, delta)
  *                 mag = magnitude(delta)
  *                 if mag == 0: continue             # <<<<<<<<<<<<<<
@@ -5521,64 +5488,64 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
               goto __pyx_L19_continue;
             }
 
-            /* "orangecontrib/network/_fr_layout.pyx":188
+            /* "orangecontrib/network/_fr_layout.pyx":187
  *                 mag = magnitude(delta)
  *                 if mag == 0: continue
  *                 for d in range(n_dim):             # <<<<<<<<<<<<<<
  *                     adj = delta[d] / mag * weight * _Fa(k, mag)
  *                     disp[row, d] -= adj
  */
-            __pyx_t_18 = __pyx_v_n_dim;
-            for (__pyx_t_19 = 0; __pyx_t_19 < __pyx_t_18; __pyx_t_19+=1) {
-              __pyx_v_d = __pyx_t_19;
+            __pyx_t_17 = __pyx_v_n_dim;
+            for (__pyx_t_18 = 0; __pyx_t_18 < __pyx_t_17; __pyx_t_18+=1) {
+              __pyx_v_d = __pyx_t_18;
 
-              /* "orangecontrib/network/_fr_layout.pyx":189
+              /* "orangecontrib/network/_fr_layout.pyx":188
  *                 if mag == 0: continue
  *                 for d in range(n_dim):
  *                     adj = delta[d] / mag * weight * _Fa(k, mag)             # <<<<<<<<<<<<<<
  *                     disp[row, d] -= adj
  *                     disp[col, d] += adj
  */
-              __pyx_t_34 = __pyx_v_d;
-              __pyx_v_adj = ((((*((double *) ( /* dim=0 */ (__pyx_v_delta.data + __pyx_t_34 * __pyx_v_delta.strides[0]) ))) / __pyx_v_mag) * __pyx_v_weight) * __pyx_f_13orangecontrib_7network_10_fr_layout__Fa(__pyx_v_k, __pyx_v_mag));
+              __pyx_t_33 = __pyx_v_d;
+              __pyx_v_adj = ((((*((double *) ( /* dim=0 */ (__pyx_v_delta.data + __pyx_t_33 * __pyx_v_delta.strides[0]) ))) / __pyx_v_mag) * __pyx_v_weight) * __pyx_f_13orangecontrib_7network_10_fr_layout__Fa(__pyx_v_k, __pyx_v_mag));
 
-              /* "orangecontrib/network/_fr_layout.pyx":190
+              /* "orangecontrib/network/_fr_layout.pyx":189
  *                 for d in range(n_dim):
  *                     adj = delta[d] / mag * weight * _Fa(k, mag)
  *                     disp[row, d] -= adj             # <<<<<<<<<<<<<<
  *                     disp[col, d] += adj
  *             # Gravity; tend toward center
  */
-              __pyx_t_35 = __pyx_v_row;
-              __pyx_t_36 = __pyx_v_d;
-              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_35 * __pyx_v_disp.strides[0]) ) + __pyx_t_36 * __pyx_v_disp.strides[1]) )) -= __pyx_v_adj;
+              __pyx_t_34 = __pyx_v_row;
+              __pyx_t_35 = __pyx_v_d;
+              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_34 * __pyx_v_disp.strides[0]) ) + __pyx_t_35 * __pyx_v_disp.strides[1]) )) -= __pyx_v_adj;
 
-              /* "orangecontrib/network/_fr_layout.pyx":191
+              /* "orangecontrib/network/_fr_layout.pyx":190
  *                     adj = delta[d] / mag * weight * _Fa(k, mag)
  *                     disp[row, d] -= adj
  *                     disp[col, d] += adj             # <<<<<<<<<<<<<<
  *             # Gravity; tend toward center
  *             for i in range(n_nodes):
  */
-              __pyx_t_37 = __pyx_v_col;
-              __pyx_t_38 = __pyx_v_d;
-              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_37 * __pyx_v_disp.strides[0]) ) + __pyx_t_38 * __pyx_v_disp.strides[1]) )) += __pyx_v_adj;
+              __pyx_t_36 = __pyx_v_col;
+              __pyx_t_37 = __pyx_v_d;
+              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_36 * __pyx_v_disp.strides[0]) ) + __pyx_t_37 * __pyx_v_disp.strides[1]) )) += __pyx_v_adj;
             }
             __pyx_L19_continue:;
           }
 
-          /* "orangecontrib/network/_fr_layout.pyx":193
+          /* "orangecontrib/network/_fr_layout.pyx":192
  *                     disp[col, d] += adj
  *             # Gravity; tend toward center
  *             for i in range(n_nodes):             # <<<<<<<<<<<<<<
  *                 mag = magnitude2(pos, i)
  *                 for d in range(n_dim):
  */
-          __pyx_t_15 = __pyx_v_n_nodes;
-          for (__pyx_t_16 = 0; __pyx_t_16 < __pyx_t_15; __pyx_t_16+=1) {
-            __pyx_v_i = __pyx_t_16;
+          __pyx_t_14 = __pyx_v_n_nodes;
+          for (__pyx_t_15 = 0; __pyx_t_15 < __pyx_t_14; __pyx_t_15+=1) {
+            __pyx_v_i = __pyx_t_15;
 
-            /* "orangecontrib/network/_fr_layout.pyx":194
+            /* "orangecontrib/network/_fr_layout.pyx":193
  *             # Gravity; tend toward center
  *             for i in range(n_nodes):
  *                 mag = magnitude2(pos, i)             # <<<<<<<<<<<<<<
@@ -5587,89 +5554,89 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  */
             __pyx_v_mag = __pyx_f_13orangecontrib_7network_10_fr_layout_magnitude2(__pyx_v_pos, __pyx_v_i);
 
-            /* "orangecontrib/network/_fr_layout.pyx":195
+            /* "orangecontrib/network/_fr_layout.pyx":194
  *             for i in range(n_nodes):
  *                 mag = magnitude2(pos, i)
  *                 for d in range(n_dim):             # <<<<<<<<<<<<<<
  *                     disp[i, d] -= k * GRAVITY * mag * pos[i, d]
  *             # Keep fixed nodes fixed
  */
-            __pyx_t_18 = __pyx_v_n_dim;
-            for (__pyx_t_19 = 0; __pyx_t_19 < __pyx_t_18; __pyx_t_19+=1) {
-              __pyx_v_d = __pyx_t_19;
+            __pyx_t_17 = __pyx_v_n_dim;
+            for (__pyx_t_18 = 0; __pyx_t_18 < __pyx_t_17; __pyx_t_18+=1) {
+              __pyx_v_d = __pyx_t_18;
 
-              /* "orangecontrib/network/_fr_layout.pyx":196
+              /* "orangecontrib/network/_fr_layout.pyx":195
  *                 mag = magnitude2(pos, i)
  *                 for d in range(n_dim):
  *                     disp[i, d] -= k * GRAVITY * mag * pos[i, d]             # <<<<<<<<<<<<<<
  *             # Keep fixed nodes fixed
  *             for i in range(fixed.shape[0]):
  */
-              __pyx_t_39 = __pyx_v_i;
-              __pyx_t_40 = __pyx_v_d;
-              __pyx_t_41 = __pyx_v_i;
-              __pyx_t_42 = __pyx_v_d;
-              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_41 * __pyx_v_disp.strides[0]) ) + __pyx_t_42 * __pyx_v_disp.strides[1]) )) -= (((__pyx_v_k * __pyx_v_GRAVITY) * __pyx_v_mag) * (*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_39 * __pyx_v_pos.strides[0]) ) + __pyx_t_40 * __pyx_v_pos.strides[1]) ))));
+              __pyx_t_38 = __pyx_v_i;
+              __pyx_t_39 = __pyx_v_d;
+              __pyx_t_40 = __pyx_v_i;
+              __pyx_t_41 = __pyx_v_d;
+              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_40 * __pyx_v_disp.strides[0]) ) + __pyx_t_41 * __pyx_v_disp.strides[1]) )) -= (((__pyx_v_k * __pyx_v_GRAVITY) * __pyx_v_mag) * (*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_38 * __pyx_v_pos.strides[0]) ) + __pyx_t_39 * __pyx_v_pos.strides[1]) ))));
             }
           }
 
-          /* "orangecontrib/network/_fr_layout.pyx":198
+          /* "orangecontrib/network/_fr_layout.pyx":197
  *                     disp[i, d] -= k * GRAVITY * mag * pos[i, d]
  *             # Keep fixed nodes fixed
  *             for i in range(fixed.shape[0]):             # <<<<<<<<<<<<<<
  *                 i = fixed[i]
  *                 for d in range(n_dim):
  */
-          __pyx_t_15 = (__pyx_v_fixed.shape[0]);
-          for (__pyx_t_16 = 0; __pyx_t_16 < __pyx_t_15; __pyx_t_16+=1) {
-            __pyx_v_i = __pyx_t_16;
+          __pyx_t_14 = (__pyx_v_fixed.shape[0]);
+          for (__pyx_t_15 = 0; __pyx_t_15 < __pyx_t_14; __pyx_t_15+=1) {
+            __pyx_v_i = __pyx_t_15;
 
-            /* "orangecontrib/network/_fr_layout.pyx":199
+            /* "orangecontrib/network/_fr_layout.pyx":198
  *             # Keep fixed nodes fixed
  *             for i in range(fixed.shape[0]):
  *                 i = fixed[i]             # <<<<<<<<<<<<<<
  *                 for d in range(n_dim):
  *                     disp[i, d] = 0
  */
-            __pyx_t_43 = __pyx_v_i;
-            __pyx_v_i = (*((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_fixed.data + __pyx_t_43 * __pyx_v_fixed.strides[0]) )));
+            __pyx_t_42 = __pyx_v_i;
+            __pyx_v_i = (*((__pyx_t_5numpy_int32_t *) ( /* dim=0 */ (__pyx_v_fixed.data + __pyx_t_42 * __pyx_v_fixed.strides[0]) )));
 
-            /* "orangecontrib/network/_fr_layout.pyx":200
+            /* "orangecontrib/network/_fr_layout.pyx":199
  *             for i in range(fixed.shape[0]):
  *                 i = fixed[i]
  *                 for d in range(n_dim):             # <<<<<<<<<<<<<<
  *                     disp[i, d] = 0
  *             # Limit the maximum displacement
  */
-            __pyx_t_18 = __pyx_v_n_dim;
-            for (__pyx_t_19 = 0; __pyx_t_19 < __pyx_t_18; __pyx_t_19+=1) {
-              __pyx_v_d = __pyx_t_19;
+            __pyx_t_17 = __pyx_v_n_dim;
+            for (__pyx_t_18 = 0; __pyx_t_18 < __pyx_t_17; __pyx_t_18+=1) {
+              __pyx_v_d = __pyx_t_18;
 
-              /* "orangecontrib/network/_fr_layout.pyx":201
+              /* "orangecontrib/network/_fr_layout.pyx":200
  *                 i = fixed[i]
  *                 for d in range(n_dim):
  *                     disp[i, d] = 0             # <<<<<<<<<<<<<<
  *             # Limit the maximum displacement
  *             for i in range(n_nodes):
  */
-              __pyx_t_44 = __pyx_v_i;
-              __pyx_t_45 = __pyx_v_d;
-              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_44 * __pyx_v_disp.strides[0]) ) + __pyx_t_45 * __pyx_v_disp.strides[1]) )) = 0.0;
+              __pyx_t_43 = __pyx_v_i;
+              __pyx_t_44 = __pyx_v_d;
+              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_43 * __pyx_v_disp.strides[0]) ) + __pyx_t_44 * __pyx_v_disp.strides[1]) )) = 0.0;
             }
           }
 
-          /* "orangecontrib/network/_fr_layout.pyx":203
+          /* "orangecontrib/network/_fr_layout.pyx":202
  *                     disp[i, d] = 0
  *             # Limit the maximum displacement
  *             for i in range(n_nodes):             # <<<<<<<<<<<<<<
  *                 mag = magnitude2(disp, i)
  *                 if mag == 0: continue
  */
-          __pyx_t_15 = __pyx_v_n_nodes;
-          for (__pyx_t_16 = 0; __pyx_t_16 < __pyx_t_15; __pyx_t_16+=1) {
-            __pyx_v_i = __pyx_t_16;
+          __pyx_t_14 = __pyx_v_n_nodes;
+          for (__pyx_t_15 = 0; __pyx_t_15 < __pyx_t_14; __pyx_t_15+=1) {
+            __pyx_v_i = __pyx_t_15;
 
-            /* "orangecontrib/network/_fr_layout.pyx":204
+            /* "orangecontrib/network/_fr_layout.pyx":203
  *             # Limit the maximum displacement
  *             for i in range(n_nodes):
  *                 mag = magnitude2(disp, i)             # <<<<<<<<<<<<<<
@@ -5678,7 +5645,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  */
             __pyx_v_mag = __pyx_f_13orangecontrib_7network_10_fr_layout_magnitude2(__pyx_v_disp, __pyx_v_i);
 
-            /* "orangecontrib/network/_fr_layout.pyx":205
+            /* "orangecontrib/network/_fr_layout.pyx":204
  *             for i in range(n_nodes):
  *                 mag = magnitude2(disp, i)
  *                 if mag == 0: continue             # <<<<<<<<<<<<<<
@@ -5690,61 +5657,61 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
               goto __pyx_L32_continue;
             }
 
-            /* "orangecontrib/network/_fr_layout.pyx":206
+            /* "orangecontrib/network/_fr_layout.pyx":205
  *                 mag = magnitude2(disp, i)
  *                 if mag == 0: continue
  *                 for d in range(n_dim):             # <<<<<<<<<<<<<<
  *                     pos[i, d] += disp[i, d] / mag * min(fabs(disp[i, d]), temp)
  *             # Optionally call back with the new positions
  */
-            __pyx_t_18 = __pyx_v_n_dim;
-            for (__pyx_t_19 = 0; __pyx_t_19 < __pyx_t_18; __pyx_t_19+=1) {
-              __pyx_v_d = __pyx_t_19;
+            __pyx_t_17 = __pyx_v_n_dim;
+            for (__pyx_t_18 = 0; __pyx_t_18 < __pyx_t_17; __pyx_t_18+=1) {
+              __pyx_v_d = __pyx_t_18;
 
-              /* "orangecontrib/network/_fr_layout.pyx":207
+              /* "orangecontrib/network/_fr_layout.pyx":206
  *                 if mag == 0: continue
  *                 for d in range(n_dim):
  *                     pos[i, d] += disp[i, d] / mag * min(fabs(disp[i, d]), temp)             # <<<<<<<<<<<<<<
  *             # Optionally call back with the new positions
  *             if iteration % callback_freq == 0 and have_callback:
  */
-              __pyx_t_46 = __pyx_v_i;
-              __pyx_t_47 = __pyx_v_d;
-              __pyx_t_33 = __pyx_v_temp;
-              __pyx_t_48 = __pyx_v_i;
-              __pyx_t_49 = __pyx_v_d;
-              __pyx_t_50 = fabs((*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_48 * __pyx_v_disp.strides[0]) ) + __pyx_t_49 * __pyx_v_disp.strides[1]) ))));
-              if (((__pyx_t_33 < __pyx_t_50) != 0)) {
-                __pyx_t_51 = __pyx_t_33;
+              __pyx_t_45 = __pyx_v_i;
+              __pyx_t_46 = __pyx_v_d;
+              __pyx_t_32 = __pyx_v_temp;
+              __pyx_t_47 = __pyx_v_i;
+              __pyx_t_48 = __pyx_v_d;
+              __pyx_t_49 = fabs((*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_47 * __pyx_v_disp.strides[0]) ) + __pyx_t_48 * __pyx_v_disp.strides[1]) ))));
+              if (((__pyx_t_32 < __pyx_t_49) != 0)) {
+                __pyx_t_50 = __pyx_t_32;
               } else {
-                __pyx_t_51 = __pyx_t_50;
+                __pyx_t_50 = __pyx_t_49;
               }
-              __pyx_t_52 = __pyx_v_i;
-              __pyx_t_53 = __pyx_v_d;
-              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_52 * __pyx_v_pos.strides[0]) ) + __pyx_t_53 * __pyx_v_pos.strides[1]) )) += (((*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_46 * __pyx_v_disp.strides[0]) ) + __pyx_t_47 * __pyx_v_disp.strides[1]) ))) / __pyx_v_mag) * __pyx_t_51);
+              __pyx_t_51 = __pyx_v_i;
+              __pyx_t_52 = __pyx_v_d;
+              *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_51 * __pyx_v_pos.strides[0]) ) + __pyx_t_52 * __pyx_v_pos.strides[1]) )) += (((*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_disp.data + __pyx_t_45 * __pyx_v_disp.strides[0]) ) + __pyx_t_46 * __pyx_v_disp.strides[1]) ))) / __pyx_v_mag) * __pyx_t_50);
             }
             __pyx_L32_continue:;
           }
 
-          /* "orangecontrib/network/_fr_layout.pyx":209
+          /* "orangecontrib/network/_fr_layout.pyx":208
  *                     pos[i, d] += disp[i, d] / mag * min(fabs(disp[i, d]), temp)
  *             # Optionally call back with the new positions
  *             if iteration % callback_freq == 0 and have_callback:             # <<<<<<<<<<<<<<
  *                 with gil:
  *                     if not callback(np.asarray(pos), (iteration+1.0)/iterations):
  */
-          __pyx_t_54 = (((__pyx_v_iteration % __pyx_v_callback_freq) == 0) != 0);
-          if (__pyx_t_54) {
+          __pyx_t_53 = (((__pyx_v_iteration % __pyx_v_callback_freq) == 0) != 0);
+          if (__pyx_t_53) {
           } else {
-            __pyx_t_9 = __pyx_t_54;
+            __pyx_t_9 = __pyx_t_53;
             goto __pyx_L38_bool_binop_done;
           }
-          __pyx_t_54 = (__pyx_v_have_callback != 0);
-          __pyx_t_9 = __pyx_t_54;
+          __pyx_t_53 = (__pyx_v_have_callback != 0);
+          __pyx_t_9 = __pyx_t_53;
           __pyx_L38_bool_binop_done:;
           if (__pyx_t_9) {
 
-            /* "orangecontrib/network/_fr_layout.pyx":210
+            /* "orangecontrib/network/_fr_layout.pyx":209
  *             # Optionally call back with the new positions
  *             if iteration % callback_freq == 0 and have_callback:
  *                 with gil:             # <<<<<<<<<<<<<<
@@ -5757,19 +5724,19 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
                 #endif
                 /*try:*/ {
 
-                  /* "orangecontrib/network/_fr_layout.pyx":211
+                  /* "orangecontrib/network/_fr_layout.pyx":210
  *             if iteration % callback_freq == 0 and have_callback:
  *                 with gil:
  *                     if not callback(np.asarray(pos), (iteration+1.0)/iterations):             # <<<<<<<<<<<<<<
  *                         break
  *     return pos
  */
-                  __pyx_t_6 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 211, __pyx_L43_error)
+                  __pyx_t_6 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 210, __pyx_L43_error)
                   __Pyx_GOTREF(__pyx_t_6);
-                  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 211, __pyx_L43_error)
+                  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 210, __pyx_L43_error)
                   __Pyx_GOTREF(__pyx_t_3);
                   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-                  __pyx_t_6 = __pyx_memoryview_fromslice(__pyx_v_pos, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 211, __pyx_L43_error)
+                  __pyx_t_6 = __pyx_memoryview_fromslice(__pyx_v_pos, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 210, __pyx_L43_error)
                   __Pyx_GOTREF(__pyx_t_6);
                   __pyx_t_2 = NULL;
                   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -5782,14 +5749,14 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
                     }
                   }
                   if (!__pyx_t_2) {
-                    __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_6); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 211, __pyx_L43_error)
+                    __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_6); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 210, __pyx_L43_error)
                     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
                     __Pyx_GOTREF(__pyx_t_4);
                   } else {
                     #if CYTHON_FAST_PYCALL
                     if (PyFunction_Check(__pyx_t_3)) {
                       PyObject *__pyx_temp[2] = {__pyx_t_2, __pyx_t_6};
-                      __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 211, __pyx_L43_error)
+                      __pyx_t_4 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 210, __pyx_L43_error)
                       __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
                       __Pyx_GOTREF(__pyx_t_4);
                       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
@@ -5798,44 +5765,44 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
                     #if CYTHON_FAST_PYCCALL
                     if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
                       PyObject *__pyx_temp[2] = {__pyx_t_2, __pyx_t_6};
-                      __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 211, __pyx_L43_error)
+                      __pyx_t_4 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 210, __pyx_L43_error)
                       __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
                       __Pyx_GOTREF(__pyx_t_4);
                       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
                     } else
                     #endif
                     {
-                      __pyx_t_55 = PyTuple_New(1+1); if (unlikely(!__pyx_t_55)) __PYX_ERR(0, 211, __pyx_L43_error)
-                      __Pyx_GOTREF(__pyx_t_55);
-                      __Pyx_GIVEREF(__pyx_t_2); PyTuple_SET_ITEM(__pyx_t_55, 0, __pyx_t_2); __pyx_t_2 = NULL;
+                      __pyx_t_54 = PyTuple_New(1+1); if (unlikely(!__pyx_t_54)) __PYX_ERR(0, 210, __pyx_L43_error)
+                      __Pyx_GOTREF(__pyx_t_54);
+                      __Pyx_GIVEREF(__pyx_t_2); PyTuple_SET_ITEM(__pyx_t_54, 0, __pyx_t_2); __pyx_t_2 = NULL;
                       __Pyx_GIVEREF(__pyx_t_6);
-                      PyTuple_SET_ITEM(__pyx_t_55, 0+1, __pyx_t_6);
+                      PyTuple_SET_ITEM(__pyx_t_54, 0+1, __pyx_t_6);
                       __pyx_t_6 = 0;
-                      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_55, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 211, __pyx_L43_error)
+                      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_54, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 210, __pyx_L43_error)
                       __Pyx_GOTREF(__pyx_t_4);
-                      __Pyx_DECREF(__pyx_t_55); __pyx_t_55 = 0;
+                      __Pyx_DECREF(__pyx_t_54); __pyx_t_54 = 0;
                     }
                   }
                   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-                  __pyx_t_3 = PyFloat_FromDouble(((__pyx_v_iteration + 1.0) / ((double)__pyx_v_iterations))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 211, __pyx_L43_error)
+                  __pyx_t_3 = PyFloat_FromDouble(((__pyx_v_iteration + 1.0) / ((double)__pyx_v_iterations))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 210, __pyx_L43_error)
                   __Pyx_GOTREF(__pyx_t_3);
                   __Pyx_INCREF(__pyx_v_callback);
-                  __pyx_t_55 = __pyx_v_callback; __pyx_t_6 = NULL;
-                  __pyx_t_56 = 0;
-                  if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_55))) {
-                    __pyx_t_6 = PyMethod_GET_SELF(__pyx_t_55);
+                  __pyx_t_54 = __pyx_v_callback; __pyx_t_6 = NULL;
+                  __pyx_t_55 = 0;
+                  if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_54))) {
+                    __pyx_t_6 = PyMethod_GET_SELF(__pyx_t_54);
                     if (likely(__pyx_t_6)) {
-                      PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_55);
+                      PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_54);
                       __Pyx_INCREF(__pyx_t_6);
                       __Pyx_INCREF(function);
-                      __Pyx_DECREF_SET(__pyx_t_55, function);
-                      __pyx_t_56 = 1;
+                      __Pyx_DECREF_SET(__pyx_t_54, function);
+                      __pyx_t_55 = 1;
                     }
                   }
                   #if CYTHON_FAST_PYCALL
-                  if (PyFunction_Check(__pyx_t_55)) {
+                  if (PyFunction_Check(__pyx_t_54)) {
                     PyObject *__pyx_temp[3] = {__pyx_t_6, __pyx_t_4, __pyx_t_3};
-                    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_55, __pyx_temp+1-__pyx_t_56, 2+__pyx_t_56); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 211, __pyx_L43_error)
+                    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_54, __pyx_temp+1-__pyx_t_55, 2+__pyx_t_55); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 210, __pyx_L43_error)
                     __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
                     __Pyx_GOTREF(__pyx_t_1);
                     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -5843,9 +5810,9 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
                   } else
                   #endif
                   #if CYTHON_FAST_PYCCALL
-                  if (__Pyx_PyFastCFunction_Check(__pyx_t_55)) {
+                  if (__Pyx_PyFastCFunction_Check(__pyx_t_54)) {
                     PyObject *__pyx_temp[3] = {__pyx_t_6, __pyx_t_4, __pyx_t_3};
-                    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_55, __pyx_temp+1-__pyx_t_56, 2+__pyx_t_56); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 211, __pyx_L43_error)
+                    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_54, __pyx_temp+1-__pyx_t_55, 2+__pyx_t_55); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 210, __pyx_L43_error)
                     __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
                     __Pyx_GOTREF(__pyx_t_1);
                     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -5853,28 +5820,28 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
                   } else
                   #endif
                   {
-                    __pyx_t_2 = PyTuple_New(2+__pyx_t_56); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 211, __pyx_L43_error)
+                    __pyx_t_2 = PyTuple_New(2+__pyx_t_55); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 210, __pyx_L43_error)
                     __Pyx_GOTREF(__pyx_t_2);
                     if (__pyx_t_6) {
                       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_6); __pyx_t_6 = NULL;
                     }
                     __Pyx_GIVEREF(__pyx_t_4);
-                    PyTuple_SET_ITEM(__pyx_t_2, 0+__pyx_t_56, __pyx_t_4);
+                    PyTuple_SET_ITEM(__pyx_t_2, 0+__pyx_t_55, __pyx_t_4);
                     __Pyx_GIVEREF(__pyx_t_3);
-                    PyTuple_SET_ITEM(__pyx_t_2, 1+__pyx_t_56, __pyx_t_3);
+                    PyTuple_SET_ITEM(__pyx_t_2, 1+__pyx_t_55, __pyx_t_3);
                     __pyx_t_4 = 0;
                     __pyx_t_3 = 0;
-                    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_55, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 211, __pyx_L43_error)
+                    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_54, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 210, __pyx_L43_error)
                     __Pyx_GOTREF(__pyx_t_1);
                     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
                   }
-                  __Pyx_DECREF(__pyx_t_55); __pyx_t_55 = 0;
-                  __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 211, __pyx_L43_error)
+                  __Pyx_DECREF(__pyx_t_54); __pyx_t_54 = 0;
+                  __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 210, __pyx_L43_error)
                   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-                  __pyx_t_54 = ((!__pyx_t_9) != 0);
-                  if (__pyx_t_54) {
+                  __pyx_t_53 = ((!__pyx_t_9) != 0);
+                  if (__pyx_t_53) {
 
-                    /* "orangecontrib/network/_fr_layout.pyx":212
+                    /* "orangecontrib/network/_fr_layout.pyx":211
  *                 with gil:
  *                     if not callback(np.asarray(pos), (iteration+1.0)/iterations):
  *                         break             # <<<<<<<<<<<<<<
@@ -5882,7 +5849,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  */
                     goto __pyx_L41_break;
 
-                    /* "orangecontrib/network/_fr_layout.pyx":211
+                    /* "orangecontrib/network/_fr_layout.pyx":210
  *             if iteration % callback_freq == 0 and have_callback:
  *                 with gil:
  *                     if not callback(np.asarray(pos), (iteration+1.0)/iterations):             # <<<<<<<<<<<<<<
@@ -5892,7 +5859,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
                   }
                 }
 
-                /* "orangecontrib/network/_fr_layout.pyx":210
+                /* "orangecontrib/network/_fr_layout.pyx":209
  *             # Optionally call back with the new positions
  *             if iteration % callback_freq == 0 and have_callback:
  *                 with gil:             # <<<<<<<<<<<<<<
@@ -5922,7 +5889,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
                 }
             }
 
-            /* "orangecontrib/network/_fr_layout.pyx":209
+            /* "orangecontrib/network/_fr_layout.pyx":208
  *                     pos[i, d] += disp[i, d] / mag * min(fabs(disp[i, d]), temp)
  *             # Optionally call back with the new positions
  *             if iteration % callback_freq == 0 and have_callback:             # <<<<<<<<<<<<<<
@@ -5938,8 +5905,8 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
  *         arr_i1_t sample = np.zeros(sample_size, dtype=np.int32)
  *         int callback_freq = int(round(1/callback_rate))
  *     with nogil:             # <<<<<<<<<<<<<<
- *         temperature[:6] = .8
  *         for iteration in range(iterations):
+ *             temp = temperature[iteration]
  */
       /*finally:*/ {
         /*normal exit:*/{
@@ -5960,7 +5927,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
       }
   }
 
-  /* "orangecontrib/network/_fr_layout.pyx":213
+  /* "orangecontrib/network/_fr_layout.pyx":212
  *                     if not callback(np.asarray(pos), (iteration+1.0)/iterations):
  *                         break
  *     return pos             # <<<<<<<<<<<<<<
@@ -5987,8 +5954,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
   __PYX_XDEC_MEMVIEW(&__pyx_t_7, 1);
   __PYX_XDEC_MEMVIEW(&__pyx_t_8, 1);
   __PYX_XDEC_MEMVIEW(&__pyx_t_12, 1);
-  __PYX_XDEC_MEMVIEW(&__pyx_t_13, 1);
-  __Pyx_XDECREF(__pyx_t_55);
+  __Pyx_XDECREF(__pyx_t_54);
   __pyx_r.data = NULL;
   __pyx_r.memview = NULL;
   __Pyx_AddTraceback("orangecontrib.network._fr_layout._fruchterman_reingold", __pyx_clineno, __pyx_lineno, __pyx_filename);
@@ -6007,7 +5973,7 @@ static __pyx_t_13orangecontrib_7network_10_fr_layout_arr_f2_t __pyx_f_13orangeco
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":214
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":214
  *         # experimental exception made for __getbuffer__ and __releasebuffer__
  *         # -- the details of this may change.
  *         def __getbuffer__(ndarray self, Py_buffer* info, int flags):             # <<<<<<<<<<<<<<
@@ -6054,7 +6020,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __Pyx_GIVEREF(__pyx_v_info->obj);
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":220
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":220
  *             # of flags
  * 
  *             if info == NULL: return             # <<<<<<<<<<<<<<
@@ -6067,7 +6033,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     goto __pyx_L0;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":223
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":223
  * 
  *             cdef int copy_shape, i, ndim
  *             cdef int endian_detector = 1             # <<<<<<<<<<<<<<
@@ -6076,7 +6042,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_endian_detector = 1;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":224
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":224
  *             cdef int copy_shape, i, ndim
  *             cdef int endian_detector = 1
  *             cdef bint little_endian = ((<char*>&endian_detector)[0] != 0)             # <<<<<<<<<<<<<<
@@ -6085,7 +6051,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_little_endian = ((((char *)(&__pyx_v_endian_detector))[0]) != 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":226
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":226
  *             cdef bint little_endian = ((<char*>&endian_detector)[0] != 0)
  * 
  *             ndim = PyArray_NDIM(self)             # <<<<<<<<<<<<<<
@@ -6094,7 +6060,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_ndim = PyArray_NDIM(__pyx_v_self);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":228
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":228
  *             ndim = PyArray_NDIM(self)
  * 
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -6104,7 +6070,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_t_1 = (((sizeof(npy_intp)) != (sizeof(Py_ssize_t))) != 0);
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":229
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":229
  * 
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):
  *                 copy_shape = 1             # <<<<<<<<<<<<<<
@@ -6113,7 +6079,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     __pyx_v_copy_shape = 1;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":228
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":228
  *             ndim = PyArray_NDIM(self)
  * 
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -6123,7 +6089,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     goto __pyx_L4;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":231
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":231
  *                 copy_shape = 1
  *             else:
  *                 copy_shape = 0             # <<<<<<<<<<<<<<
@@ -6135,7 +6101,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   }
   __pyx_L4:;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":233
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":233
  *                 copy_shape = 0
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -6149,7 +6115,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     goto __pyx_L6_bool_binop_done;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":234
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":234
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_C_CONTIGUOUS)):             # <<<<<<<<<<<<<<
@@ -6160,7 +6126,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_t_1 = __pyx_t_2;
   __pyx_L6_bool_binop_done:;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":233
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":233
  *                 copy_shape = 0
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -6169,7 +6135,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":235
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":235
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_C_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not C contiguous")             # <<<<<<<<<<<<<<
@@ -6182,7 +6148,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __PYX_ERR(1, 235, __pyx_L1_error)
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":233
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":233
  *                 copy_shape = 0
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -6191,7 +6157,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":237
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":237
  *                 raise ValueError(u"ndarray is not C contiguous")
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -6205,7 +6171,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     goto __pyx_L9_bool_binop_done;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":238
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":238
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_F_CONTIGUOUS)):             # <<<<<<<<<<<<<<
@@ -6216,7 +6182,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_t_1 = __pyx_t_2;
   __pyx_L9_bool_binop_done:;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":237
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":237
  *                 raise ValueError(u"ndarray is not C contiguous")
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -6225,7 +6191,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":239
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":239
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_F_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not Fortran contiguous")             # <<<<<<<<<<<<<<
@@ -6238,7 +6204,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __PYX_ERR(1, 239, __pyx_L1_error)
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":237
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":237
  *                 raise ValueError(u"ndarray is not C contiguous")
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -6247,7 +6213,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":241
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":241
  *                 raise ValueError(u"ndarray is not Fortran contiguous")
  * 
  *             info.buf = PyArray_DATA(self)             # <<<<<<<<<<<<<<
@@ -6256,7 +6222,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->buf = PyArray_DATA(__pyx_v_self);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":242
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":242
  * 
  *             info.buf = PyArray_DATA(self)
  *             info.ndim = ndim             # <<<<<<<<<<<<<<
@@ -6265,7 +6231,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->ndim = __pyx_v_ndim;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":243
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":243
  *             info.buf = PyArray_DATA(self)
  *             info.ndim = ndim
  *             if copy_shape:             # <<<<<<<<<<<<<<
@@ -6275,7 +6241,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_t_1 = (__pyx_v_copy_shape != 0);
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":246
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":246
  *                 # Allocate new buffer for strides and shape info.
  *                 # This is allocated as one block, strides first.
  *                 info.strides = <Py_ssize_t*>PyObject_Malloc(sizeof(Py_ssize_t) * 2 * <size_t>ndim)             # <<<<<<<<<<<<<<
@@ -6284,7 +6250,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     __pyx_v_info->strides = ((Py_ssize_t *)PyObject_Malloc((((sizeof(Py_ssize_t)) * 2) * ((size_t)__pyx_v_ndim))));
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":247
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":247
  *                 # This is allocated as one block, strides first.
  *                 info.strides = <Py_ssize_t*>PyObject_Malloc(sizeof(Py_ssize_t) * 2 * <size_t>ndim)
  *                 info.shape = info.strides + ndim             # <<<<<<<<<<<<<<
@@ -6293,7 +6259,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     __pyx_v_info->shape = (__pyx_v_info->strides + __pyx_v_ndim);
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":248
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":248
  *                 info.strides = <Py_ssize_t*>PyObject_Malloc(sizeof(Py_ssize_t) * 2 * <size_t>ndim)
  *                 info.shape = info.strides + ndim
  *                 for i in range(ndim):             # <<<<<<<<<<<<<<
@@ -6304,7 +6270,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=1) {
       __pyx_v_i = __pyx_t_5;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":249
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":249
  *                 info.shape = info.strides + ndim
  *                 for i in range(ndim):
  *                     info.strides[i] = PyArray_STRIDES(self)[i]             # <<<<<<<<<<<<<<
@@ -6313,7 +6279,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
       (__pyx_v_info->strides[__pyx_v_i]) = (PyArray_STRIDES(__pyx_v_self)[__pyx_v_i]);
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":250
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":250
  *                 for i in range(ndim):
  *                     info.strides[i] = PyArray_STRIDES(self)[i]
  *                     info.shape[i] = PyArray_DIMS(self)[i]             # <<<<<<<<<<<<<<
@@ -6323,7 +6289,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       (__pyx_v_info->shape[__pyx_v_i]) = (PyArray_DIMS(__pyx_v_self)[__pyx_v_i]);
     }
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":243
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":243
  *             info.buf = PyArray_DATA(self)
  *             info.ndim = ndim
  *             if copy_shape:             # <<<<<<<<<<<<<<
@@ -6333,7 +6299,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     goto __pyx_L11;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":252
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":252
  *                     info.shape[i] = PyArray_DIMS(self)[i]
  *             else:
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)             # <<<<<<<<<<<<<<
@@ -6343,7 +6309,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   /*else*/ {
     __pyx_v_info->strides = ((Py_ssize_t *)PyArray_STRIDES(__pyx_v_self));
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":253
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":253
  *             else:
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)
  *                 info.shape = <Py_ssize_t*>PyArray_DIMS(self)             # <<<<<<<<<<<<<<
@@ -6354,7 +6320,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   }
   __pyx_L11:;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":254
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":254
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)
  *                 info.shape = <Py_ssize_t*>PyArray_DIMS(self)
  *             info.suboffsets = NULL             # <<<<<<<<<<<<<<
@@ -6363,7 +6329,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->suboffsets = NULL;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":255
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":255
  *                 info.shape = <Py_ssize_t*>PyArray_DIMS(self)
  *             info.suboffsets = NULL
  *             info.itemsize = PyArray_ITEMSIZE(self)             # <<<<<<<<<<<<<<
@@ -6372,7 +6338,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->itemsize = PyArray_ITEMSIZE(__pyx_v_self);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":256
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":256
  *             info.suboffsets = NULL
  *             info.itemsize = PyArray_ITEMSIZE(self)
  *             info.readonly = not PyArray_ISWRITEABLE(self)             # <<<<<<<<<<<<<<
@@ -6381,7 +6347,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->readonly = (!(PyArray_ISWRITEABLE(__pyx_v_self) != 0));
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":259
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":259
  * 
  *             cdef int t
  *             cdef char* f = NULL             # <<<<<<<<<<<<<<
@@ -6390,7 +6356,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_f = NULL;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":260
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":260
  *             cdef int t
  *             cdef char* f = NULL
  *             cdef dtype descr = self.descr             # <<<<<<<<<<<<<<
@@ -6402,7 +6368,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_v_descr = ((PyArray_Descr *)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":263
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":263
  *             cdef int offset
  * 
  *             cdef bint hasfields = PyDataType_HASFIELDS(descr)             # <<<<<<<<<<<<<<
@@ -6411,7 +6377,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_hasfields = PyDataType_HASFIELDS(__pyx_v_descr);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":265
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":265
  *             cdef bint hasfields = PyDataType_HASFIELDS(descr)
  * 
  *             if not hasfields and not copy_shape:             # <<<<<<<<<<<<<<
@@ -6429,7 +6395,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_L15_bool_binop_done:;
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":267
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":267
  *             if not hasfields and not copy_shape:
  *                 # do not call releasebuffer
  *                 info.obj = None             # <<<<<<<<<<<<<<
@@ -6442,7 +6408,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __Pyx_DECREF(__pyx_v_info->obj);
     __pyx_v_info->obj = Py_None;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":265
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":265
  *             cdef bint hasfields = PyDataType_HASFIELDS(descr)
  * 
  *             if not hasfields and not copy_shape:             # <<<<<<<<<<<<<<
@@ -6452,7 +6418,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     goto __pyx_L14;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":270
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":270
  *             else:
  *                 # need to call releasebuffer
  *                 info.obj = self             # <<<<<<<<<<<<<<
@@ -6468,7 +6434,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   }
   __pyx_L14:;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":272
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":272
  *                 info.obj = self
  * 
  *             if not hasfields:             # <<<<<<<<<<<<<<
@@ -6478,7 +6444,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_t_1 = ((!(__pyx_v_hasfields != 0)) != 0);
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":273
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":273
  * 
  *             if not hasfields:
  *                 t = descr.type_num             # <<<<<<<<<<<<<<
@@ -6488,7 +6454,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __pyx_t_4 = __pyx_v_descr->type_num;
     __pyx_v_t = __pyx_t_4;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":274
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":274
  *             if not hasfields:
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -6508,7 +6474,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     }
     __pyx_L20_next_or:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":275
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":275
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or
  *                     (descr.byteorder == c'<' and not little_endian)):             # <<<<<<<<<<<<<<
@@ -6525,7 +6491,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __pyx_t_1 = __pyx_t_2;
     __pyx_L19_bool_binop_done:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":274
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":274
  *             if not hasfields:
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -6534,7 +6500,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     if (__pyx_t_1) {
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":276
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":276
  *                 if ((descr.byteorder == c'>' and little_endian) or
  *                     (descr.byteorder == c'<' and not little_endian)):
  *                     raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -6547,7 +6513,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __PYX_ERR(1, 276, __pyx_L1_error)
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":274
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":274
  *             if not hasfields:
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -6556,7 +6522,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     }
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":277
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":277
  *                     (descr.byteorder == c'<' and not little_endian)):
  *                     raise ValueError(u"Non-native byte order not supported")
  *                 if   t == NPY_BYTE:        f = "b"             # <<<<<<<<<<<<<<
@@ -6568,7 +6534,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"b");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":278
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":278
  *                     raise ValueError(u"Non-native byte order not supported")
  *                 if   t == NPY_BYTE:        f = "b"
  *                 elif t == NPY_UBYTE:       f = "B"             # <<<<<<<<<<<<<<
@@ -6579,7 +6545,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"B");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":279
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":279
  *                 if   t == NPY_BYTE:        f = "b"
  *                 elif t == NPY_UBYTE:       f = "B"
  *                 elif t == NPY_SHORT:       f = "h"             # <<<<<<<<<<<<<<
@@ -6590,7 +6556,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"h");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":280
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":280
  *                 elif t == NPY_UBYTE:       f = "B"
  *                 elif t == NPY_SHORT:       f = "h"
  *                 elif t == NPY_USHORT:      f = "H"             # <<<<<<<<<<<<<<
@@ -6601,7 +6567,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"H");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":281
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":281
  *                 elif t == NPY_SHORT:       f = "h"
  *                 elif t == NPY_USHORT:      f = "H"
  *                 elif t == NPY_INT:         f = "i"             # <<<<<<<<<<<<<<
@@ -6612,7 +6578,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"i");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":282
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":282
  *                 elif t == NPY_USHORT:      f = "H"
  *                 elif t == NPY_INT:         f = "i"
  *                 elif t == NPY_UINT:        f = "I"             # <<<<<<<<<<<<<<
@@ -6623,7 +6589,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"I");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":283
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":283
  *                 elif t == NPY_INT:         f = "i"
  *                 elif t == NPY_UINT:        f = "I"
  *                 elif t == NPY_LONG:        f = "l"             # <<<<<<<<<<<<<<
@@ -6634,7 +6600,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"l");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":284
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":284
  *                 elif t == NPY_UINT:        f = "I"
  *                 elif t == NPY_LONG:        f = "l"
  *                 elif t == NPY_ULONG:       f = "L"             # <<<<<<<<<<<<<<
@@ -6645,7 +6611,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"L");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":285
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":285
  *                 elif t == NPY_LONG:        f = "l"
  *                 elif t == NPY_ULONG:       f = "L"
  *                 elif t == NPY_LONGLONG:    f = "q"             # <<<<<<<<<<<<<<
@@ -6656,7 +6622,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"q");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":286
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":286
  *                 elif t == NPY_ULONG:       f = "L"
  *                 elif t == NPY_LONGLONG:    f = "q"
  *                 elif t == NPY_ULONGLONG:   f = "Q"             # <<<<<<<<<<<<<<
@@ -6667,7 +6633,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"Q");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":287
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":287
  *                 elif t == NPY_LONGLONG:    f = "q"
  *                 elif t == NPY_ULONGLONG:   f = "Q"
  *                 elif t == NPY_FLOAT:       f = "f"             # <<<<<<<<<<<<<<
@@ -6678,7 +6644,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"f");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":288
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":288
  *                 elif t == NPY_ULONGLONG:   f = "Q"
  *                 elif t == NPY_FLOAT:       f = "f"
  *                 elif t == NPY_DOUBLE:      f = "d"             # <<<<<<<<<<<<<<
@@ -6689,7 +6655,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"d");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":289
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":289
  *                 elif t == NPY_FLOAT:       f = "f"
  *                 elif t == NPY_DOUBLE:      f = "d"
  *                 elif t == NPY_LONGDOUBLE:  f = "g"             # <<<<<<<<<<<<<<
@@ -6700,7 +6666,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"g");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":290
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":290
  *                 elif t == NPY_DOUBLE:      f = "d"
  *                 elif t == NPY_LONGDOUBLE:  f = "g"
  *                 elif t == NPY_CFLOAT:      f = "Zf"             # <<<<<<<<<<<<<<
@@ -6711,7 +6677,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"Zf");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":291
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":291
  *                 elif t == NPY_LONGDOUBLE:  f = "g"
  *                 elif t == NPY_CFLOAT:      f = "Zf"
  *                 elif t == NPY_CDOUBLE:     f = "Zd"             # <<<<<<<<<<<<<<
@@ -6722,7 +6688,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"Zd");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":292
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":292
  *                 elif t == NPY_CFLOAT:      f = "Zf"
  *                 elif t == NPY_CDOUBLE:     f = "Zd"
  *                 elif t == NPY_CLONGDOUBLE: f = "Zg"             # <<<<<<<<<<<<<<
@@ -6733,7 +6699,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __pyx_v_f = ((char *)"Zg");
       break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":293
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":293
  *                 elif t == NPY_CDOUBLE:     f = "Zd"
  *                 elif t == NPY_CLONGDOUBLE: f = "Zg"
  *                 elif t == NPY_OBJECT:      f = "O"             # <<<<<<<<<<<<<<
@@ -6745,7 +6711,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       default:
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":295
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":295
  *                 elif t == NPY_OBJECT:      f = "O"
  *                 else:
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)             # <<<<<<<<<<<<<<
@@ -6771,7 +6737,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
     }
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":296
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":296
  *                 else:
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  *                 info.format = f             # <<<<<<<<<<<<<<
@@ -6780,7 +6746,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     __pyx_v_info->format = __pyx_v_f;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":297
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":297
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  *                 info.format = f
  *                 return             # <<<<<<<<<<<<<<
@@ -6790,7 +6756,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __pyx_r = 0;
     goto __pyx_L0;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":272
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":272
  *                 info.obj = self
  * 
  *             if not hasfields:             # <<<<<<<<<<<<<<
@@ -6799,7 +6765,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":299
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":299
  *                 return
  *             else:
  *                 info.format = <char*>PyObject_Malloc(_buffer_format_string_len)             # <<<<<<<<<<<<<<
@@ -6809,7 +6775,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   /*else*/ {
     __pyx_v_info->format = ((char *)PyObject_Malloc(0xFF));
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":300
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":300
  *             else:
  *                 info.format = <char*>PyObject_Malloc(_buffer_format_string_len)
  *                 info.format[0] = c'^' # Native data types, manual alignment             # <<<<<<<<<<<<<<
@@ -6818,7 +6784,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     (__pyx_v_info->format[0]) = '^';
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":301
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":301
  *                 info.format = <char*>PyObject_Malloc(_buffer_format_string_len)
  *                 info.format[0] = c'^' # Native data types, manual alignment
  *                 offset = 0             # <<<<<<<<<<<<<<
@@ -6827,7 +6793,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     __pyx_v_offset = 0;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":302
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":302
  *                 info.format[0] = c'^' # Native data types, manual alignment
  *                 offset = 0
  *                 f = _util_dtypestring(descr, info.format + 1,             # <<<<<<<<<<<<<<
@@ -6837,7 +6803,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __pyx_t_7 = __pyx_f_5numpy__util_dtypestring(__pyx_v_descr, (__pyx_v_info->format + 1), (__pyx_v_info->format + 0xFF), (&__pyx_v_offset)); if (unlikely(__pyx_t_7 == ((char *)NULL))) __PYX_ERR(1, 302, __pyx_L1_error)
     __pyx_v_f = __pyx_t_7;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":305
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":305
  *                                       info.format + _buffer_format_string_len,
  *                                       &offset)
  *                 f[0] = c'\0' # Terminate format string             # <<<<<<<<<<<<<<
@@ -6847,7 +6813,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     (__pyx_v_f[0]) = '\x00';
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":214
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":214
  *         # experimental exception made for __getbuffer__ and __releasebuffer__
  *         # -- the details of this may change.
  *         def __getbuffer__(ndarray self, Py_buffer* info, int flags):             # <<<<<<<<<<<<<<
@@ -6879,7 +6845,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":307
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":307
  *                 f[0] = c'\0' # Terminate format string
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):             # <<<<<<<<<<<<<<
@@ -6903,7 +6869,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("__releasebuffer__", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":308
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":308
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):
  *             if PyArray_HASFIELDS(self):             # <<<<<<<<<<<<<<
@@ -6913,7 +6879,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
   __pyx_t_1 = (PyArray_HASFIELDS(__pyx_v_self) != 0);
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":309
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":309
  *         def __releasebuffer__(ndarray self, Py_buffer* info):
  *             if PyArray_HASFIELDS(self):
  *                 PyObject_Free(info.format)             # <<<<<<<<<<<<<<
@@ -6922,7 +6888,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  */
     PyObject_Free(__pyx_v_info->format);
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":308
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":308
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):
  *             if PyArray_HASFIELDS(self):             # <<<<<<<<<<<<<<
@@ -6931,7 +6897,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  */
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":310
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":310
  *             if PyArray_HASFIELDS(self):
  *                 PyObject_Free(info.format)
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -6941,7 +6907,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
   __pyx_t_1 = (((sizeof(npy_intp)) != (sizeof(Py_ssize_t))) != 0);
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":311
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":311
  *                 PyObject_Free(info.format)
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):
  *                 PyObject_Free(info.strides)             # <<<<<<<<<<<<<<
@@ -6950,7 +6916,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  */
     PyObject_Free(__pyx_v_info->strides);
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":310
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":310
  *             if PyArray_HASFIELDS(self):
  *                 PyObject_Free(info.format)
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -6959,7 +6925,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  */
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":307
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":307
  *                 f[0] = c'\0' # Terminate format string
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):             # <<<<<<<<<<<<<<
@@ -6971,7 +6937,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
   __Pyx_RefNannyFinishContext();
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":788
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":788
  * ctypedef npy_cdouble     complex_t
  * 
  * cdef inline object PyArray_MultiIterNew1(a):             # <<<<<<<<<<<<<<
@@ -6985,7 +6951,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew1", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":789
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":789
  * 
  * cdef inline object PyArray_MultiIterNew1(a):
  *     return PyArray_MultiIterNew(1, <void*>a)             # <<<<<<<<<<<<<<
@@ -6999,7 +6965,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":788
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":788
  * ctypedef npy_cdouble     complex_t
  * 
  * cdef inline object PyArray_MultiIterNew1(a):             # <<<<<<<<<<<<<<
@@ -7018,7 +6984,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":791
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":791
  *     return PyArray_MultiIterNew(1, <void*>a)
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):             # <<<<<<<<<<<<<<
@@ -7032,7 +6998,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew2", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":792
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":792
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)             # <<<<<<<<<<<<<<
@@ -7046,7 +7012,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":791
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":791
  *     return PyArray_MultiIterNew(1, <void*>a)
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):             # <<<<<<<<<<<<<<
@@ -7065,7 +7031,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":794
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":794
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):             # <<<<<<<<<<<<<<
@@ -7079,7 +7045,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew3", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":795
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":795
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)             # <<<<<<<<<<<<<<
@@ -7093,7 +7059,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":794
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":794
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):             # <<<<<<<<<<<<<<
@@ -7112,7 +7078,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":797
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":797
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):             # <<<<<<<<<<<<<<
@@ -7126,7 +7092,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew4", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":798
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":798
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)             # <<<<<<<<<<<<<<
@@ -7140,7 +7106,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":797
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":797
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):             # <<<<<<<<<<<<<<
@@ -7159,7 +7125,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":800
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":800
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):             # <<<<<<<<<<<<<<
@@ -7173,7 +7139,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew5", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":801
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":801
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)             # <<<<<<<<<<<<<<
@@ -7187,7 +7153,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":800
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":800
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):             # <<<<<<<<<<<<<<
@@ -7206,7 +7172,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":803
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":803
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):             # <<<<<<<<<<<<<<
@@ -7220,7 +7186,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("PyDataType_SHAPE", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":804
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":804
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  *     if PyDataType_HASSUBARRAY(d):             # <<<<<<<<<<<<<<
@@ -7230,7 +7196,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
   __pyx_t_1 = (PyDataType_HASSUBARRAY(__pyx_v_d) != 0);
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":805
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":805
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  *     if PyDataType_HASSUBARRAY(d):
  *         return <tuple>d.subarray.shape             # <<<<<<<<<<<<<<
@@ -7242,7 +7208,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
     __pyx_r = ((PyObject*)__pyx_v_d->subarray->shape);
     goto __pyx_L0;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":804
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":804
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  *     if PyDataType_HASSUBARRAY(d):             # <<<<<<<<<<<<<<
@@ -7251,7 +7217,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
  */
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":807
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":807
  *         return <tuple>d.subarray.shape
  *     else:
  *         return ()             # <<<<<<<<<<<<<<
@@ -7265,7 +7231,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
     goto __pyx_L0;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":803
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":803
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):             # <<<<<<<<<<<<<<
@@ -7280,7 +7246,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":809
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":809
  *         return ()
  * 
  * cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset) except NULL:             # <<<<<<<<<<<<<<
@@ -7309,7 +7275,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
   char *__pyx_t_9;
   __Pyx_RefNannySetupContext("_util_dtypestring", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":814
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":814
  * 
  *     cdef dtype child
  *     cdef int endian_detector = 1             # <<<<<<<<<<<<<<
@@ -7318,7 +7284,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
   __pyx_v_endian_detector = 1;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":815
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":815
  *     cdef dtype child
  *     cdef int endian_detector = 1
  *     cdef bint little_endian = ((<char*>&endian_detector)[0] != 0)             # <<<<<<<<<<<<<<
@@ -7327,7 +7293,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
   __pyx_v_little_endian = ((((char *)(&__pyx_v_endian_detector))[0]) != 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":818
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":818
  *     cdef tuple fields
  * 
  *     for childname in descr.names:             # <<<<<<<<<<<<<<
@@ -7350,7 +7316,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __Pyx_XDECREF_SET(__pyx_v_childname, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":819
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":819
  * 
  *     for childname in descr.names:
  *         fields = descr.fields[childname]             # <<<<<<<<<<<<<<
@@ -7367,7 +7333,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __Pyx_XDECREF_SET(__pyx_v_fields, ((PyObject*)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":820
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":820
  *     for childname in descr.names:
  *         fields = descr.fields[childname]
  *         child, new_offset = fields             # <<<<<<<<<<<<<<
@@ -7406,7 +7372,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __Pyx_XDECREF_SET(__pyx_v_new_offset, __pyx_t_4);
     __pyx_t_4 = 0;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":822
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":822
  *         child, new_offset = fields
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:             # <<<<<<<<<<<<<<
@@ -7423,7 +7389,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __pyx_t_6 = ((((__pyx_v_end - __pyx_v_f) - ((int)__pyx_t_5)) < 15) != 0);
     if (__pyx_t_6) {
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":823
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":823
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")             # <<<<<<<<<<<<<<
@@ -7436,7 +7402,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __PYX_ERR(1, 823, __pyx_L1_error)
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":822
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":822
  *         child, new_offset = fields
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:             # <<<<<<<<<<<<<<
@@ -7445,7 +7411,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
     }
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":825
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":825
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")
  * 
  *         if ((child.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -7465,7 +7431,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     }
     __pyx_L8_next_or:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":826
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":826
  * 
  *         if ((child.byteorder == c'>' and little_endian) or
  *             (child.byteorder == c'<' and not little_endian)):             # <<<<<<<<<<<<<<
@@ -7482,7 +7448,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __pyx_t_6 = __pyx_t_7;
     __pyx_L7_bool_binop_done:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":825
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":825
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")
  * 
  *         if ((child.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -7491,7 +7457,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
     if (__pyx_t_6) {
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":827
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":827
  *         if ((child.byteorder == c'>' and little_endian) or
  *             (child.byteorder == c'<' and not little_endian)):
  *             raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -7504,7 +7470,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __PYX_ERR(1, 827, __pyx_L1_error)
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":825
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":825
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")
  * 
  *         if ((child.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -7513,7 +7479,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
     }
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":837
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":837
  * 
  *         # Output padding bytes
  *         while offset[0] < new_offset:             # <<<<<<<<<<<<<<
@@ -7529,7 +7495,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
       if (!__pyx_t_6) break;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":838
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":838
  *         # Output padding bytes
  *         while offset[0] < new_offset:
  *             f[0] = 120 # "x"; pad byte             # <<<<<<<<<<<<<<
@@ -7538,7 +7504,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
       (__pyx_v_f[0]) = 0x78;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":839
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":839
  *         while offset[0] < new_offset:
  *             f[0] = 120 # "x"; pad byte
  *             f += 1             # <<<<<<<<<<<<<<
@@ -7547,7 +7513,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
       __pyx_v_f = (__pyx_v_f + 1);
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":840
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":840
  *             f[0] = 120 # "x"; pad byte
  *             f += 1
  *             offset[0] += 1             # <<<<<<<<<<<<<<
@@ -7558,7 +7524,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       (__pyx_v_offset[__pyx_t_8]) = ((__pyx_v_offset[__pyx_t_8]) + 1);
     }
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":842
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":842
  *             offset[0] += 1
  * 
  *         offset[0] += child.itemsize             # <<<<<<<<<<<<<<
@@ -7568,7 +7534,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __pyx_t_8 = 0;
     (__pyx_v_offset[__pyx_t_8]) = ((__pyx_v_offset[__pyx_t_8]) + __pyx_v_child->elsize);
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":844
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":844
  *         offset[0] += child.itemsize
  * 
  *         if not PyDataType_HASFIELDS(child):             # <<<<<<<<<<<<<<
@@ -7578,7 +7544,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __pyx_t_6 = ((!(PyDataType_HASFIELDS(__pyx_v_child) != 0)) != 0);
     if (__pyx_t_6) {
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":845
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":845
  * 
  *         if not PyDataType_HASFIELDS(child):
  *             t = child.type_num             # <<<<<<<<<<<<<<
@@ -7590,7 +7556,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __Pyx_XDECREF_SET(__pyx_v_t, __pyx_t_4);
       __pyx_t_4 = 0;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":846
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":846
  *         if not PyDataType_HASFIELDS(child):
  *             t = child.type_num
  *             if end - f < 5:             # <<<<<<<<<<<<<<
@@ -7600,7 +7566,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __pyx_t_6 = (((__pyx_v_end - __pyx_v_f) < 5) != 0);
       if (__pyx_t_6) {
 
-        /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":847
+        /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":847
  *             t = child.type_num
  *             if end - f < 5:
  *                 raise RuntimeError(u"Format string allocated too short.")             # <<<<<<<<<<<<<<
@@ -7613,7 +7579,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
         __PYX_ERR(1, 847, __pyx_L1_error)
 
-        /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":846
+        /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":846
  *         if not PyDataType_HASFIELDS(child):
  *             t = child.type_num
  *             if end - f < 5:             # <<<<<<<<<<<<<<
@@ -7622,7 +7588,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":850
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":850
  * 
  *             # Until ticket #99 is fixed, use integers to avoid warnings
  *             if   t == NPY_BYTE:        f[0] =  98 #"b"             # <<<<<<<<<<<<<<
@@ -7640,7 +7606,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":851
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":851
  *             # Until ticket #99 is fixed, use integers to avoid warnings
  *             if   t == NPY_BYTE:        f[0] =  98 #"b"
  *             elif t == NPY_UBYTE:       f[0] =  66 #"B"             # <<<<<<<<<<<<<<
@@ -7658,7 +7624,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":852
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":852
  *             if   t == NPY_BYTE:        f[0] =  98 #"b"
  *             elif t == NPY_UBYTE:       f[0] =  66 #"B"
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"             # <<<<<<<<<<<<<<
@@ -7676,7 +7642,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":853
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":853
  *             elif t == NPY_UBYTE:       f[0] =  66 #"B"
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"             # <<<<<<<<<<<<<<
@@ -7694,7 +7660,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":854
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":854
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"
  *             elif t == NPY_INT:         f[0] = 105 #"i"             # <<<<<<<<<<<<<<
@@ -7712,7 +7678,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":855
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":855
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"
  *             elif t == NPY_INT:         f[0] = 105 #"i"
  *             elif t == NPY_UINT:        f[0] =  73 #"I"             # <<<<<<<<<<<<<<
@@ -7730,7 +7696,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":856
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":856
  *             elif t == NPY_INT:         f[0] = 105 #"i"
  *             elif t == NPY_UINT:        f[0] =  73 #"I"
  *             elif t == NPY_LONG:        f[0] = 108 #"l"             # <<<<<<<<<<<<<<
@@ -7748,7 +7714,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":857
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":857
  *             elif t == NPY_UINT:        f[0] =  73 #"I"
  *             elif t == NPY_LONG:        f[0] = 108 #"l"
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"             # <<<<<<<<<<<<<<
@@ -7766,7 +7732,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":858
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":858
  *             elif t == NPY_LONG:        f[0] = 108 #"l"
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"             # <<<<<<<<<<<<<<
@@ -7784,7 +7750,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":859
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":859
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"             # <<<<<<<<<<<<<<
@@ -7802,7 +7768,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":860
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":860
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"             # <<<<<<<<<<<<<<
@@ -7820,7 +7786,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":861
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":861
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"             # <<<<<<<<<<<<<<
@@ -7838,7 +7804,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":862
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":862
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"             # <<<<<<<<<<<<<<
@@ -7856,7 +7822,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":863
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":863
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf             # <<<<<<<<<<<<<<
@@ -7876,7 +7842,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":864
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":864
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd             # <<<<<<<<<<<<<<
@@ -7896,7 +7862,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":865
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":865
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd
  *             elif t == NPY_CLONGDOUBLE: f[0] = 90; f[1] = 103; f += 1 # Zg             # <<<<<<<<<<<<<<
@@ -7916,7 +7882,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":866
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":866
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd
  *             elif t == NPY_CLONGDOUBLE: f[0] = 90; f[1] = 103; f += 1 # Zg
  *             elif t == NPY_OBJECT:      f[0] = 79 #"O"             # <<<<<<<<<<<<<<
@@ -7934,7 +7900,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":868
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":868
  *             elif t == NPY_OBJECT:      f[0] = 79 #"O"
  *             else:
  *                 raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)             # <<<<<<<<<<<<<<
@@ -7958,7 +7924,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       }
       __pyx_L15:;
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":869
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":869
  *             else:
  *                 raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  *             f += 1             # <<<<<<<<<<<<<<
@@ -7967,7 +7933,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
       __pyx_v_f = (__pyx_v_f + 1);
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":844
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":844
  *         offset[0] += child.itemsize
  * 
  *         if not PyDataType_HASFIELDS(child):             # <<<<<<<<<<<<<<
@@ -7977,7 +7943,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       goto __pyx_L13;
     }
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":873
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":873
  *             # Cython ignores struct boundary information ("T{...}"),
  *             # so don't output it
  *             f = _util_dtypestring(child, f, end, offset)             # <<<<<<<<<<<<<<
@@ -7990,7 +7956,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     }
     __pyx_L13:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":818
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":818
  *     cdef tuple fields
  * 
  *     for childname in descr.names:             # <<<<<<<<<<<<<<
@@ -8000,7 +7966,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":874
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":874
  *             # so don't output it
  *             f = _util_dtypestring(child, f, end, offset)
  *     return f             # <<<<<<<<<<<<<<
@@ -8010,7 +7976,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
   __pyx_r = __pyx_v_f;
   goto __pyx_L0;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":809
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":809
  *         return ()
  * 
  * cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset) except NULL:             # <<<<<<<<<<<<<<
@@ -8035,7 +8001,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":990
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":990
  * 
  * 
  * cdef inline void set_array_base(ndarray arr, object base):             # <<<<<<<<<<<<<<
@@ -8050,7 +8016,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
   int __pyx_t_2;
   __Pyx_RefNannySetupContext("set_array_base", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":992
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":992
  * cdef inline void set_array_base(ndarray arr, object base):
  *      cdef PyObject* baseptr
  *      if base is None:             # <<<<<<<<<<<<<<
@@ -8061,7 +8027,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":993
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":993
  *      cdef PyObject* baseptr
  *      if base is None:
  *          baseptr = NULL             # <<<<<<<<<<<<<<
@@ -8070,7 +8036,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  */
     __pyx_v_baseptr = NULL;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":992
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":992
  * cdef inline void set_array_base(ndarray arr, object base):
  *      cdef PyObject* baseptr
  *      if base is None:             # <<<<<<<<<<<<<<
@@ -8080,7 +8046,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
     goto __pyx_L3;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":995
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":995
  *          baseptr = NULL
  *      else:
  *          Py_INCREF(base) # important to do this before decref below!             # <<<<<<<<<<<<<<
@@ -8090,7 +8056,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
   /*else*/ {
     Py_INCREF(__pyx_v_base);
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":996
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":996
  *      else:
  *          Py_INCREF(base) # important to do this before decref below!
  *          baseptr = <PyObject*>base             # <<<<<<<<<<<<<<
@@ -8101,7 +8067,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
   }
   __pyx_L3:;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":997
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":997
  *          Py_INCREF(base) # important to do this before decref below!
  *          baseptr = <PyObject*>base
  *      Py_XDECREF(arr.base)             # <<<<<<<<<<<<<<
@@ -8110,7 +8076,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  */
   Py_XDECREF(__pyx_v_arr->base);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":998
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":998
  *          baseptr = <PyObject*>base
  *      Py_XDECREF(arr.base)
  *      arr.base = baseptr             # <<<<<<<<<<<<<<
@@ -8119,7 +8085,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  */
   __pyx_v_arr->base = __pyx_v_baseptr;
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":990
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":990
  * 
  * 
  * cdef inline void set_array_base(ndarray arr, object base):             # <<<<<<<<<<<<<<
@@ -8131,7 +8097,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
   __Pyx_RefNannyFinishContext();
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1000
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1000
  *      arr.base = baseptr
  * 
  * cdef inline object get_array_base(ndarray arr):             # <<<<<<<<<<<<<<
@@ -8145,7 +8111,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("get_array_base", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1001
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1001
  * 
  * cdef inline object get_array_base(ndarray arr):
  *     if arr.base is NULL:             # <<<<<<<<<<<<<<
@@ -8155,7 +8121,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   __pyx_t_1 = ((__pyx_v_arr->base == NULL) != 0);
   if (__pyx_t_1) {
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1002
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1002
  * cdef inline object get_array_base(ndarray arr):
  *     if arr.base is NULL:
  *         return None             # <<<<<<<<<<<<<<
@@ -8167,7 +8133,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
     __pyx_r = Py_None;
     goto __pyx_L0;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1001
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1001
  * 
  * cdef inline object get_array_base(ndarray arr):
  *     if arr.base is NULL:             # <<<<<<<<<<<<<<
@@ -8176,7 +8142,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
  */
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1004
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1004
  *         return None
  *     else:
  *         return <object>arr.base             # <<<<<<<<<<<<<<
@@ -8190,7 +8156,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
     goto __pyx_L0;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1000
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1000
  *      arr.base = baseptr
  * 
  * cdef inline object get_array_base(ndarray arr):             # <<<<<<<<<<<<<<
@@ -8205,7 +8171,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1009
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1009
  * # Versions of the import_* functions which are more suitable for
  * # Cython code.
  * cdef inline int import_array() except -1:             # <<<<<<<<<<<<<<
@@ -8226,7 +8192,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
   PyObject *__pyx_t_8 = NULL;
   __Pyx_RefNannySetupContext("import_array", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1010
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1010
  * # Cython code.
  * cdef inline int import_array() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -8242,7 +8208,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     __Pyx_XGOTREF(__pyx_t_3);
     /*try:*/ {
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1011
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1011
  * cdef inline int import_array() except -1:
  *     try:
  *         _import_array()             # <<<<<<<<<<<<<<
@@ -8251,7 +8217,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
  */
       __pyx_t_4 = _import_array(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 1011, __pyx_L3_error)
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1010
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1010
  * # Cython code.
  * cdef inline int import_array() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -8265,7 +8231,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     goto __pyx_L8_try_end;
     __pyx_L3_error:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1012
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1012
  *     try:
  *         _import_array()
  *     except Exception:             # <<<<<<<<<<<<<<
@@ -8280,7 +8246,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GOTREF(__pyx_t_7);
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1013
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1013
  *         _import_array()
  *     except Exception:
  *         raise ImportError("numpy.core.multiarray failed to import")             # <<<<<<<<<<<<<<
@@ -8296,7 +8262,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     goto __pyx_L5_except_error;
     __pyx_L5_except_error:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1010
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1010
  * # Cython code.
  * cdef inline int import_array() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -8311,7 +8277,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     __pyx_L8_try_end:;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1009
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1009
  * # Versions of the import_* functions which are more suitable for
  * # Cython code.
  * cdef inline int import_array() except -1:             # <<<<<<<<<<<<<<
@@ -8334,7 +8300,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1015
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1015
  *         raise ImportError("numpy.core.multiarray failed to import")
  * 
  * cdef inline int import_umath() except -1:             # <<<<<<<<<<<<<<
@@ -8355,7 +8321,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
   PyObject *__pyx_t_8 = NULL;
   __Pyx_RefNannySetupContext("import_umath", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1016
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1016
  * 
  * cdef inline int import_umath() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -8371,7 +8337,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     __Pyx_XGOTREF(__pyx_t_3);
     /*try:*/ {
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1017
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1017
  * cdef inline int import_umath() except -1:
  *     try:
  *         _import_umath()             # <<<<<<<<<<<<<<
@@ -8380,7 +8346,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
  */
       __pyx_t_4 = _import_umath(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 1017, __pyx_L3_error)
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1016
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1016
  * 
  * cdef inline int import_umath() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -8394,7 +8360,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     goto __pyx_L8_try_end;
     __pyx_L3_error:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1018
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1018
  *     try:
  *         _import_umath()
  *     except Exception:             # <<<<<<<<<<<<<<
@@ -8409,7 +8375,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GOTREF(__pyx_t_7);
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1019
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1019
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
@@ -8425,7 +8391,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     goto __pyx_L5_except_error;
     __pyx_L5_except_error:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1016
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1016
  * 
  * cdef inline int import_umath() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -8440,7 +8406,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     __pyx_L8_try_end:;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1015
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1015
  *         raise ImportError("numpy.core.multiarray failed to import")
  * 
  * cdef inline int import_umath() except -1:             # <<<<<<<<<<<<<<
@@ -8463,7 +8429,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
   return __pyx_r;
 }
 
-/* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1021
+/* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1021
  *         raise ImportError("numpy.core.umath failed to import")
  * 
  * cdef inline int import_ufunc() except -1:             # <<<<<<<<<<<<<<
@@ -8484,7 +8450,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
   PyObject *__pyx_t_8 = NULL;
   __Pyx_RefNannySetupContext("import_ufunc", 0);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1022
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1022
  * 
  * cdef inline int import_ufunc() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -8500,7 +8466,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     __Pyx_XGOTREF(__pyx_t_3);
     /*try:*/ {
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1023
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1023
  * cdef inline int import_ufunc() except -1:
  *     try:
  *         _import_umath()             # <<<<<<<<<<<<<<
@@ -8509,7 +8475,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
  */
       __pyx_t_4 = _import_umath(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 1023, __pyx_L3_error)
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1022
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1022
  * 
  * cdef inline int import_ufunc() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -8523,7 +8489,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     goto __pyx_L8_try_end;
     __pyx_L3_error:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1024
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1024
  *     try:
  *         _import_umath()
  *     except Exception:             # <<<<<<<<<<<<<<
@@ -8537,7 +8503,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GOTREF(__pyx_t_7);
 
-      /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1025
+      /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1025
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
@@ -8551,7 +8517,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     goto __pyx_L5_except_error;
     __pyx_L5_except_error:;
 
-    /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1022
+    /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1022
  * 
  * cdef inline int import_ufunc() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -8566,7 +8532,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     __pyx_L8_try_end:;
   }
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1021
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1021
  *         raise ImportError("numpy.core.umath failed to import")
  * 
  * cdef inline int import_ufunc() except -1:             # <<<<<<<<<<<<<<
@@ -22279,7 +22245,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple_);
   __Pyx_GIVEREF(__pyx_tuple_);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":235
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":235
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_C_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not C contiguous")             # <<<<<<<<<<<<<<
@@ -22290,7 +22256,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__2);
   __Pyx_GIVEREF(__pyx_tuple__2);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":239
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":239
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_F_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not Fortran contiguous")             # <<<<<<<<<<<<<<
@@ -22301,7 +22267,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__3);
   __Pyx_GIVEREF(__pyx_tuple__3);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":276
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":276
  *                 if ((descr.byteorder == c'>' and little_endian) or
  *                     (descr.byteorder == c'<' and not little_endian)):
  *                     raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -22312,7 +22278,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__4);
   __Pyx_GIVEREF(__pyx_tuple__4);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":823
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":823
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")             # <<<<<<<<<<<<<<
@@ -22323,7 +22289,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__5);
   __Pyx_GIVEREF(__pyx_tuple__5);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":827
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":827
  *         if ((child.byteorder == c'>' and little_endian) or
  *             (child.byteorder == c'<' and not little_endian)):
  *             raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -22334,7 +22300,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__6);
   __Pyx_GIVEREF(__pyx_tuple__6);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":847
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":847
  *             t = child.type_num
  *             if end - f < 5:
  *                 raise RuntimeError(u"Format string allocated too short.")             # <<<<<<<<<<<<<<
@@ -22345,7 +22311,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__7);
   __Pyx_GIVEREF(__pyx_tuple__7);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1013
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1013
  *         _import_array()
  *     except Exception:
  *         raise ImportError("numpy.core.multiarray failed to import")             # <<<<<<<<<<<<<<
@@ -22356,7 +22322,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__8);
   __Pyx_GIVEREF(__pyx_tuple__8);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1019
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1019
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
@@ -22367,7 +22333,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__9);
   __Pyx_GIVEREF(__pyx_tuple__9);
 
-  /* "../../../../venvs/orange3/lib/python3.5/site-packages/Cython/Includes/numpy/__init__.pxd":1025
+  /* "../../../../../python/python36-32/lib/site-packages/Cython/Includes/numpy/__init__.pxd":1025
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
@@ -22664,10 +22630,10 @@ static int __Pyx_InitCachedConstants(void) {
 
 static int __Pyx_InitGlobals(void) {
   if (__Pyx_InitStrings(__pyx_string_tab) < 0) __PYX_ERR(0, 1, __pyx_L1_error);
-  __pyx_float__4 = PyFloat_FromDouble(.4); if (unlikely(!__pyx_float__4)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_float__5 = PyFloat_FromDouble(.5); if (unlikely(!__pyx_float__5)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_float__05 = PyFloat_FromDouble(.05); if (unlikely(!__pyx_float__05)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_float_0_1 = PyFloat_FromDouble(0.1); if (unlikely(!__pyx_float_0_1)) __PYX_ERR(0, 1, __pyx_L1_error)
+  __pyx_float__001 = PyFloat_FromDouble(.001); if (unlikely(!__pyx_float__001)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_float_0_25 = PyFloat_FromDouble(0.25); if (unlikely(!__pyx_float_0_25)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_int_0 = PyInt_FromLong(0); if (unlikely(!__pyx_int_0)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_int_1 = PyInt_FromLong(1); if (unlikely(!__pyx_int_1)) __PYX_ERR(0, 1, __pyx_L1_error)

--- a/orangecontrib/network/_fr_layout.pyx
+++ b/orangecontrib/network/_fr_layout.pyx
@@ -149,7 +149,7 @@ cdef arr_f2_t _fruchterman_reingold(arr_f1_t Edata,  # COO matrix constituents
                                     double callback_rate):
     cdef:
         double GRAVITY = 20
-        arr_f1_t temperature = np.linspace(.4, .05, iterations)
+        arr_f1_t temperature = np.linspace(.05, .001, iterations)
         arr_f2_t disp = np.empty((pos.shape[0], pos.shape[1]))
         arr_f1_t delta = np.empty(pos.shape[1])
         double mag, adj, weight, temp
@@ -162,7 +162,6 @@ cdef arr_f2_t _fruchterman_reingold(arr_f1_t Edata,  # COO matrix constituents
         arr_i1_t sample = np.zeros(sample_size, dtype=np.int32)
         int callback_freq = int(round(1/callback_rate))
     with nogil:
-        temperature[:6] = .8
         for iteration in range(iterations):
             temp = temperature[iteration]
             disp[:, :] = 0

--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -97,6 +97,7 @@ class OWNxExplorer(widget.OWWidget):
     tabIndex = Setting(0)
     showEdgeWeights = Setting(False)
     relativeEdgeWidths = Setting(False)
+    randomizePositions = Setting(True)
     invertNodeSize = Setting(False)
     markDistance = Setting(1)
     markSearchString = Setting("")
@@ -169,6 +170,7 @@ class OWNxExplorer(widget.OWWidget):
 
         self.relayout_button = gui.button(box, self, 'Re-layout',
                                           callback=self.relayout, autoDefault=False)
+        self.randomize_cb = gui.checkBox(box, self, "randomizePositions", "Randomize positions")
         self.view.positionsChanged.connect(lambda positions, progress:
                                            self.progressbar.widget.progressBarSet(int(round(100 * progress))))
         def animationFinished():
@@ -492,6 +494,7 @@ class OWNxExplorer(widget.OWWidget):
         self.Error.clear()
 
         self.set_selection_mode()
+        self.randomizePositions = True
         self.relayout()
 
     @Inputs.node_data
@@ -545,7 +548,7 @@ class OWNxExplorer(widget.OWWidget):
         self.Warning.distance_matrix_size.clear()
 
         self.relayout_button.setDisabled(True)
-        self.view.relayout(randomize=False, weight=distmatrix)
+        self.view.relayout(randomize=self.randomizePositions, weight=distmatrix)
 
     def _on_node_label_attrs_changed(self):
         if not self.graph: return

--- a/orangecontrib/network/widgets/graphview.py
+++ b/orangecontrib/network/widgets/graphview.py
@@ -242,6 +242,7 @@ class GraphView(QGraphicsView):
         scene.setBspTreeDepth(2)
         self.setScene(scene)
         self.setSceneRect(-1e5, -1e5, 2e5, 2e5)
+        self.scaleFactor = 300
         self.setText('')
 
         self.setCacheMode(self.CacheBackground)
@@ -439,9 +440,8 @@ class GraphView(QGraphicsView):
         if weight is None: weight = 'weight'
         pos, graphview = None, self
         if not randomize:
-            pos = [[pos.x(), pos.y()]
-                   for pos in (node.pos()
-                               for node in self.nodes)]
+            pos = np.array([[pos.x(), pos.y()]
+                            for pos in (node.pos()/self.scaleFactor for node in self.nodes)])
 
         class AnimationThread(Thread):
             def __init__(self, iterations, callback):
@@ -471,7 +471,7 @@ class GraphView(QGraphicsView):
         return self._is_animating
 
     def _update_positions(self, positions, _):
-        for node, pos in zip(self.nodes, positions*300):
+        for node, pos in zip(self.nodes, positions*self.scaleFactor):
             node.setPos(*pos)
         qApp.processEvents()
 


### PR DESCRIPTION
##### Description of changes
Added an option for re-layout with or without randomization.

Reduced the temperature schedule for a smoother visualization of networks and re-layout of visualizations that were modified/improved by hand (by dragging some sets of nodes to appropriate places).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
