### PR TITLE
travis: pin PyQt5==5.9.2 to avoid segfault

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - pip install codecov
 
 install:
-    - pip install PyQt5 AnyQt
+    - pip install PyQt5==5.9.2 AnyQt
     - travis_wait pip install -e .
 
 script:


### PR DESCRIPTION
##### Issue
Fix travis build.


##### Description of changes
Pin PyQt5 to 5.9.2

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
