### PR TITLE
OWNxClustering: Fix crash when Cluster variable existed in data

### DIFF
--- a/orangecontrib/network/community.py
+++ b/orangecontrib/network/community.py
@@ -18,23 +18,20 @@ import networkx as nx
 from Orange.data import Domain, Table, DiscreteVariable
 
 
-CLUSTERING_LABEL = 'Cluster'
-
-
-def add_results_to_items(G, labels):
+def add_results_to_items(G, labels, var_name):
     items = G.items()
-    if items is not None and CLUSTERING_LABEL in items.domain:
+    if items is not None and var_name in items.domain:
         domain = Domain([a for a in items.domain.attributes
-                         if a.name != CLUSTERING_LABEL],
+                         if a.name != var_name],
                         items.domain.class_vars,
                         items.domain.metas)
         items = Table.from_table(domain, items)
 
     attrs = [DiscreteVariable(
-        CLUSTERING_LABEL,
+        var_name,
         values=["C%d" % (x + 1) for x in set(labels.values())])]
 
-    domain = Domain(attrs)
+    domain = Domain([], metas=attrs)
     data = Table(domain, [[l] for l in labels.values()])
 
     if items is None:
@@ -52,16 +49,12 @@ class CommunityDetection(object):
         return self.algorithm(G, **self.kwargs)
 
 
-def label_propagation_hop_attenuation(G, results2items=0, iterations=1000,
+def label_propagation_hop_attenuation(G, iterations=1000,
                                       delta=0.1, node_degree_preference=0):
     """Label propagation for community detection, Leung et al., 2009
 
     :param G: A Orange graph.
     :type G: Orange.network.Graph
-
-    :param results2items: Append a new feature result to items
-        (Orange.data.Table).
-    :type results2items: bool
 
     :param iterations: The max. number of iterations if no convergence.
     :type iterations: int
@@ -114,21 +107,14 @@ def label_propagation_hop_attenuation(G, results2items=0, iterations=1000,
 
     labels = remap_labels(labels)
 
-    if results2items:
-        add_results_to_items(G, labels)
-
     return labels
 
 
-def label_propagation(G, results2items=0, iterations=1000, seed=None):
+def label_propagation(G, iterations=1000, seed=None):
     """Label propagation for community detection, Raghavan et al., 2007
 
     :param G: A Orange graph.
     :type G: Orange.network.Graph
-
-    :param results2items: Append a new feature result to items
-        (Orange.data.Table).
-    :type results2items: bool
 
     :param iterations: The maximum number of iterations if there is no convergence.
     :type iterations: int
@@ -180,9 +166,6 @@ def label_propagation(G, results2items=0, iterations=1000, seed=None):
                 break
 
     labels = remap_labels(labels)
-
-    if results2items:
-        add_results_to_items(G, labels)
 
     return labels
 

--- a/orangecontrib/network/widgets/OWNxClustering.py
+++ b/orangecontrib/network/widgets/OWNxClustering.py
@@ -2,6 +2,7 @@ from AnyQt.QtCore import Qt
 
 from Orange.data import Table
 from Orange.widgets import gui, widget, settings
+from Orange.widgets.utils.annotated_data import get_next_name
 from Orange.widgets.widget import Input, Output
 from orangecontrib.network import Graph, community as cd
 
@@ -62,13 +63,11 @@ class OWNxClustering(widget.OWWidget):
 
         if self.method == 0:
             alg = cd.label_propagation
-            kwargs = {'results2items': 1,
-                      'iterations': self.iterations}
+            kwargs = {'iterations': self.iterations}
 
         elif self.method == 1:
             alg = cd.label_propagation_hop_attenuation
-            kwargs = {'results2items': 1,
-                      'iterations': self.iterations,
+            kwargs = {'iterations': self.iterations,
                       'delta': self.hop_attenuation}
 
         if self.net is None:
@@ -77,6 +76,8 @@ class OWNxClustering(widget.OWWidget):
             return
 
         labels = alg(self.net, **kwargs)
+        domain = self.net.items().domain
+        cd.add_results_to_items(self.net, labels, get_next_name(domain, 'Cluster'))
 
         self.info.setText('%d clusters found' % len(set(labels.values())))
         self.Outputs.items.send(self.net.items())

--- a/orangecontrib/network/widgets/tests/test_OWNxClustering.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxClustering.py
@@ -1,0 +1,35 @@
+import networkx as nx
+import numpy as np
+
+from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
+from Orange.widgets.tests.base import WidgetTest
+from orangecontrib.network.widgets.OWNxClustering import OWNxClustering
+from orangecontrib.network.network import Graph
+
+
+class TestOWNxClustering(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(
+            OWNxClustering, stored_settings={'autoApply': False},
+        )  # type: OWNxClustering
+
+    def test_does_not_crash_when_cluster_variable_already_exists(self):
+        # Prepare some dummy data
+        x, clusters = np.ones((5, 1)), np.ones((5, 1))
+
+        data_var = ContinuousVariable('Data')
+        cluster_var = DiscreteVariable('Cluster', ('C1', 'C2'))
+        data = Table.from_numpy(
+            Domain([data_var], metas=[cluster_var]),
+            X=x, metas=clusters,
+        )
+        graph = Graph(nx.complete_graph(5), '5-Clique')
+        graph.set_items(data)
+
+        # Should not crash
+        self.send_signal(self.widget.Inputs.network, graph)
+        self.widget.unconditional_commit()
+
+        # There should be an additional cluster column
+        output = self.get_output(self.widget.Outputs.network).items()
+        self.assertEqual(len(data.domain.metas) + 1, len(output.domain.metas))


### PR DESCRIPTION
##### Issue
Crashed when node data domain already contained variable named "Cluster".


##### Description of changes
Fix. Move cluster annotations from `target_var` to metas.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
