### PR TITLE
Network Explorer: Fix wrong method name (stop_optimization_blocking)

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -626,7 +626,7 @@ class OWNxExplorer(OWDataProjectionWidget):
             self._animation_thread = None
 
     def onDeleteWidget(self):
-        self.stop_optimization_blocking()
+        self.stop_optimization_and_wait()
         super().onDeleteWidget()
 
     def send_report(self):


### PR DESCRIPTION
`onDeleteWidget` called a method with a wrong name, which for some unknown reason remained unnoticed.