### PR TITLE
OWNxFile: Catch all exceptions in reader

### DIFF
--- a/orangecontrib/network/widgets/tests/test_OWNxFile.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxFile.py
@@ -1,0 +1,27 @@
+import os
+import unittest
+from unittest.mock import patch, Mock
+
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.network.widgets.OWNxFile import OWNxFile
+import orangecontrib.network
+
+class TestOWNxExplorer(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWNxFile)  # type: OWNxFile
+
+    def test_read_error(self):
+        with patch("orangecontrib.network.readwrite.read",
+                   Mock(side_effect=ValueError)):
+            self.widget.openNetFile("foo.net")
+        self.assertTrue(self.widget.Error.error_reading_file.is_shown())
+        filename = os.path.join(
+            os.path.split(orangecontrib.network.__file__)[0],
+            "networks/leu_by_genesets.net")
+        self.widget.openNetFile(filename)
+        self.assertFalse(self.widget.Error.error_reading_file.is_shown())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

Network widget does not handle exceptions thrown in file readers. In the worst case, this can even prevent the widget from initializing if the file it attempts to read is invalid.

This bug was first tackled in #89, but the problem does not occur only in `__init__` (where #89 fixes it), and it's a result of inappropriate handling of exceptions in the function that calls the reader, so it should be fixed there.

##### Description of changes

Improved handling of exceptions.

##### Includes
- [X] Code changes
- [X] Tests
