### PR TITLE
Test with Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: false
 dist: trusty
-python: "3.5"
+python: "3.6"
 
 cache:
     apt: true


### PR DESCRIPTION
Orange is now tested with Python 3.6.