### PR TITLE
OWNetworkExplorer: Inherit warnings and errors from DataProjectionWidget class.

### DIFF
--- a/orangecontrib/network/network/readwrite.py
+++ b/orangecontrib/network/network/readwrite.py
@@ -59,7 +59,8 @@ def read_pajek(path):
         if labels is None:
             raise ValueError("Vertices must be defined before edges or arcs")
 
-    lines = [line.strip() for line in open(path)]
+    with open(path) as f:
+        lines = [line.strip() for line in f]
     lines = np.array([line for line in lines if line and line[0] != "%"])
     part_starts = [(line_no, line)
                    for line_no, line in enumerate(lines)

--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -36,7 +36,7 @@ class OWNxExplorer(OWDataProjectionWidget):
         distances = Output("Distance matrix", Orange.misc.DistMatrix)
 
     UserAdviceMessages = [
-        widget.Message('Double clicks select connected components',
+        widget.Message("Double clicks select connected components",
                        widget.Message.Information),
     ]
 
@@ -51,16 +51,16 @@ class OWNxExplorer(OWDataProjectionWidget):
 
     alpha_value = 255  # Override the setting from parent
 
-    class Warning(widget.OWWidget.Warning):
+    class Warning(OWDataProjectionWidget.Warning):
         distance_matrix_mismatch = widget.Msg(
             "Distance matrix size doesn't match the number of network nodes "
-            " and will be ignored.")
-        no_graph_found = widget.Msg('Node data is given, graph data is missing')
+            "and will be ignored.")
+        no_graph_found = widget.Msg("Node data is given, graph data is missing.")
 
-    class Error(widget.OWWidget.Error):
+    class Error(OWDataProjectionWidget.Error):
         data_size_mismatch = widget.Msg(
-            'Length of the data does not match the number of nodes.')
-        network_too_large = widget.Msg('Network is too large to visualize.')
+            "Length of the data does not match the number of nodes.")
+        network_too_large = widget.Msg("Network is too large to visualize.")
         single_node_graph = widget.Msg("I don't do single-node graphs today.")
 
     def __init__(self):

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -1,11 +1,47 @@
+import os
+
+from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest
+from orangewidget.tests.utils import simulate
+
+import orangecontrib
+from orangecontrib.network.widgets.OWNxFile import OWNxFile
 from orangecontrib.network.widgets.OWNxExplorer import OWNxExplorer
 
 
 class TestOWNxExplorer(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWNxExplorer)  # type: OWNxExplorer
+        self.network = self._read_network("lastfm.net")
+        self.data = self._read_items("lastfm.tab")
 
     def test_minimum_size(self):
         # Disable this test from the base test class
         pass
+
+    def test_too_many_labels(self):
+        # check that Warning is shown when attribute
+        # with too many labels is chosen
+        # GH - 120
+        self.send_signal(self.widget.Inputs.network, self.network)
+        self.send_signal(self.widget.Inputs.node_data, self.data)
+        simulate.combobox_activate_item(self.widget.controls.attr_label,
+                                        self.data.domain.metas[0].name)
+        self.assertTrue(self.widget.Warning.too_many_labels.is_shown())
+        simulate.combobox_activate_index(self.widget.controls.attr_label, 0)
+        self.assertFalse(self.widget.Warning.too_many_labels.is_shown())
+
+    def _read_network(self, filename=None):
+        owfile = self.create_widget(OWNxFile)
+        owfile.open_net_file(self._get_filename(filename, "n"))
+        return self.get_output(owfile.Outputs.network, widget=owfile)
+
+    def _read_items(self, filename=None):
+        return Table(self._get_filename(filename))
+
+    def _get_filename(self, filename, mode="d"):
+        path = os.path.split(orangecontrib.network.__file__)[0]
+        if filename is None:
+            path = os.path.join(path, "widgets", "tests")
+            filename = "test_items.tab" if mode == "d" else "test.net"
+        return os.path.join(path, os.path.join("networks", filename))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #120. 

##### Description of changes
- Inherit warnings and errors from OWDataProjectionWidget class instead of base widget class.
- Replace single quotes with double for warnings.
- Add tests.
- Fix a small error in reading the file.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
