### PR TITLE
OWNetworkExplorer: fix selecting a subset in the plot

### DIFF
--- a/orangecontrib/network/network/base.py
+++ b/orangecontrib/network/network/base.py
@@ -73,7 +73,7 @@ class Edges:
         edge_mask = np.logical_and(mask[edges.row], mask[edges.col])
         row = node_renumeration[edges.row[edge_mask]]
         col = node_renumeration[edges.col[edge_mask]]
-        data = self.data[edge_mask]
+        data = edges.data[edge_mask]
         edge_data = self.edge_data[edge_mask] if self.edge_data is not None \
             else None
         return type(self)(

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -1,13 +1,17 @@
 import os
+import numpy as np
 
+import orangecontrib
 from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest
 from orangewidget.tests.utils import simulate
 
-import orangecontrib
+from orangecontrib.network import Network
 from orangecontrib.network.widgets.OWNxFile import OWNxFile
 from orangecontrib.network.widgets.OWNxExplorer import OWNxExplorer
 
+
+cwd = os.path.split(__file__)[0]
 
 class TestOWNxExplorer(WidgetTest):
     def setUp(self):
@@ -30,6 +34,15 @@ class TestOWNxExplorer(WidgetTest):
         self.assertTrue(self.widget.Warning.too_many_labels.is_shown())
         simulate.combobox_activate_index(self.widget.controls.attr_label, 0)
         self.assertFalse(self.widget.Warning.too_many_labels.is_shown())
+
+    def test_subset_selection(self):
+        # test if selecting from the graph works
+
+        self.send_signal(self.widget.Inputs.network, self.network)
+        self.send_signal(self.widget.Inputs.node_data, self.data)
+        self.widget.graph.selection_select(np.arange(0, 5))
+        outputs = self.widget.Outputs
+        self.assertIsInstance(self.get_output(outputs.subgraph), Network)
 
     def _read_network(self, filename=None):
         owfile = self.create_widget(OWNxFile)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #121. 

##### Description of changes
Fix the call for selecting a subset and add tests.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
