### PR TITLE
OWNxFromDistances: fix selection of nodes

### DIFF
--- a/orangecontrib/network/network/base.py
+++ b/orangecontrib/network/network/base.py
@@ -254,7 +254,10 @@ class Network:
 
     def subgraph(self, mask):
         nodes = self.nodes[mask]
-        coordinates = self.coordinates[mask]
+        if self.coordinates is not None:
+            coordinates = self.coordinates[mask]
+        else:
+            coordinates = None
         if mask.dtype is not np.bool:
             mask1 = np.full((self.number_of_nodes(),), False)
             mask1[mask] = True

--- a/orangecontrib/network/widgets/OWNxFromDistances.py
+++ b/orangecontrib/network/widgets/OWNxFromDistances.py
@@ -248,11 +248,12 @@ class OWNxFromDistances(widget.OWWidget):
             # exclude unconnected
             if self.node_selection != NodeSelection.ALL_NODES:
                 n_components, components = csgraph.connected_components(edges)
-                counts = np.bincount(components, minlength=n_components + 1)
+                counts = np.bincount(components)
                 if self.node_selection == NodeSelection.COMPONENTS:
-                    mask = counts >= self.excludeLimit
+                    ind = np.flatnonzero(counts >= self.excludeLimit)
+                    mask = np.in1d(components, ind)
                 else:
-                    mask = counts == np.argmax(counts)
+                    mask = components == np.argmax(counts)
                 graph = graph.subgraph(mask)
 
         self.graph = graph

--- a/orangecontrib/network/widgets/tests/test_OWNxFromDistances.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxFromDistances.py
@@ -1,0 +1,36 @@
+import unittest
+
+from Orange.data import Table
+from Orange.distance import Euclidean
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.network.widgets.OWNxFromDistances import OWNxFromDistances
+
+
+class TestOWNxFromDistances(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWNxFromDistances) # type: OWNxFromDistances
+        self.data = Table("iris")
+        self.distances = Euclidean(self.data)
+
+    def test_minimum_size(self):
+        # Disable this test from the base test class
+        pass
+
+    def test_node_selection(self):
+        self.send_signal(self.widget.Inputs.distances, self.distances)
+        net = self.get_output(self.widget.Outputs.network)
+        self.assertTrue(net)
+        self.assertEqual(net.number_of_nodes(), len(self.data))
+        self.widget.controls.node_selection.buttons[1].click()
+        net = self.get_output(self.widget.Outputs.network)
+        self.assertTrue(net)
+        self.assertEqual(net.number_of_nodes(), 84)
+        self.widget.controls.node_selection.buttons[2].click()
+        net = self.get_output(self.widget.Outputs.network)
+        self.assertTrue(net)
+        self.assertEqual(net.number_of_nodes(), 36)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Network from Distances crashed on Largest Component and Component with at least N nodes.

##### Description of changes
Correctly compute masks for selection of subsets.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
