### PR TITLE
Network explorer fixes

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -351,6 +351,7 @@ class OWNxExplorer(OWDataProjectionWidget):
 
     def selection_changed(self):
         super().selection_changed()
+        self.nSelected = 0 if self.selection is None else len(self.selection)
         self.update_selection_buttons()
         self.update_marks()
 

--- a/orangecontrib/network/widgets/graphview.py
+++ b/orangecontrib/network/widgets/graphview.py
@@ -306,9 +306,9 @@ class GraphView(OWScatterPlotBase):
         # Poor man's double click
         indices = [p.data() for p in points]
         last_time, last_indices = self.last_click
+        self.last_click = (time.time(), indices)
         if time.time() - last_time < 0.5 and indices == last_indices:
             indices = self.master.get_reachable(indices)
-        self.last_click = (time.time(), indices)
         self.select_by_indices(indices)
 
     def unselect_all(self):

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -33,10 +33,12 @@ class TestOWNxExplorer(NetworkTest):
         # test if selecting from the graph works
 
         self.send_signal(self.widget.Inputs.network, self.network)
+        self.assertEqual(self.widget.nSelected, 0)
         self.send_signal(self.widget.Inputs.node_data, self.data)
         self.widget.graph.selection_select(np.arange(0, 5))
         outputs = self.widget.Outputs
         self.assertIsInstance(self.get_output(outputs.subgraph), Network)
+        self.assertEqual(self.widget.nSelected, 5)
 
     def test_get_reachable(self):
         # gene label indices, which are equal to their numbers assigned in the .net file - 1

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -1,3 +1,5 @@
+import unittest
+
 import numpy as np
 
 from orangecontrib.network.widgets.tests.utils import NetworkTest
@@ -49,8 +51,10 @@ class TestOWNxExplorer(NetworkTest):
         self.assertSetEqual(set(self.widget.get_reachable([GENES["PSMA2"]])),
                             {GENES["PSMA2"], GENES["PSMA4"], GENES["PSMA5"], GENES["PSMA6"]})
         # test that zero-weight edges do not get dropped due to sparse matrix representation
-        # (GH-128)
         self.assertSetEqual(set(self.widget.get_reachable([GENES["IDS"]])),
                             {GENES["IDS"], GENES["GNS"]})
         self.assertSetEqual(set(self.widget.get_reachable([GENES["BLVRB"]])),
                             {GENES["BLVRB"], GENES["HMOX1"], GENES["BLVRA"]})
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -37,3 +37,18 @@ class TestOWNxExplorer(NetworkTest):
         self.widget.graph.selection_select(np.arange(0, 5))
         outputs = self.widget.Outputs
         self.assertIsInstance(self.get_output(outputs.subgraph), Network)
+
+    def test_get_reachable(self):
+        # gene label indices, which are equal to their numbers assigned in the .net file - 1
+        GENES = {"IDS": 70, "GNS": 36, "BLVRB": 61, "HMOX1": 5, "BLVRA": 62,
+                 "PSMA2": 6, "PSMA4": 8, "PSMA5": 9, "PSMA6": 7}
+        self.send_signal(self.widget.Inputs.network, self._read_network("leu_by_genesets.net"))
+
+        self.assertSetEqual(set(self.widget.get_reachable([GENES["PSMA2"]])),
+                            {GENES["PSMA2"], GENES["PSMA4"], GENES["PSMA5"], GENES["PSMA6"]})
+        # test that zero-weight edges do not get dropped due to sparse matrix representation
+        # (GH-128)
+        self.assertSetEqual(set(self.widget.get_reachable([GENES["IDS"]])),
+                            {GENES["IDS"], GENES["GNS"]})
+        self.assertSetEqual(set(self.widget.get_reachable([GENES["BLVRB"]])),
+                            {GENES["BLVRB"], GENES["HMOX1"], GENES["BLVRA"]})


### PR DESCRIPTION
##### Issue
Fixes #128.
Also makes the counter for selected nodes work.


##### Description of changes
#128 describes two issues:
1. _For some nodes, its component does not get selected._ 
This is due to the fact that edges are represented with sparse matrices. The following line accounts for the bidirectional links, but when summing two sparse matrices, the explicit zeros (i.e. edges with zero weight) get lost.  
`self.twoway_edges = self.edges + self.edges.transpose()`
Therefore, neighbors of a node, that are connected by a single, zero weight edge, are not found anymore. 
The proposed solution is to manually re-add the zero weight edges.
2. _Upon triple clicking on a node, an error pops up._ 
This is due to a method returning a `np.array`, which then produces a `np.array` of booleans, for which the "truthness" is not defined.
The proposed solution is to return a `list` instead of a `np.array`.

The failing tests seem to have something to do with a `Table.concatenate` call in `community.py`, I'm not sure why these tests did not fail in the clustering PR :thinking: -> edit: failing tests fixed in #137

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
