### PR TITLE
[FIX] Fix failing clustering tests

### DIFF
--- a/orangecontrib/network/network/community.py
+++ b/orangecontrib/network/network/community.py
@@ -20,14 +20,16 @@ from Orange.data import Domain, Table, DiscreteVariable
 def add_results_to_items(G, labels, var_name):
     items = G.nodes
 
-    new_attr = DiscreteVariable(var_name, values=["C%d" % (x + 1) for x in set(labels.values())])
-    new_data = np.array([[l] for l in labels.values()])
+    new_attr = DiscreteVariable(
+        var_name, values=["C%d" % (x + 1) for x in set(labels.values())])
+    new_data = np.array(list(labels.values())).reshape(-1, 1)
 
     if items is not None:
-        # a unique `var_name` is assumed to be obtained in OWNxClustering prior to calling this;
-        # only check metas to enable overriding results on multiple reruns
-        effective_metas = list(filter(lambda idx: items.domain.metas[idx].name != var_name,
-                                      range(len(items.domain.metas))))
+        # a unique `var_name` is assumed to be obtained in OWNxClustering prior
+        # to calling this; only check metas to enable overriding results on
+        # multiple reruns
+        effective_metas = [idx for idx, meta in enumerate(items.domain.metas)
+                           if meta.name != var_name]
         metas = np.take(items.domain.metas, effective_metas).tolist()
         metas.append(new_attr)
 


### PR DESCRIPTION
##### Issue
Fixes tests that are failing due to the use of deprecated `Table.concatenate` in `community.py`.


##### Description of changes
Remove the use of `Table.concatenate` and replace it with an alternative way, similar to the one, suggested here: https://github.com/biolab/orange3/issues/3908#issuecomment-506643467

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
