### PR TITLE
Pajek Reader: Fixes in node indices and edge weights

### DIFF
--- a/orangecontrib/network/network/readwrite.py
+++ b/orangecontrib/network/network/readwrite.py
@@ -35,6 +35,11 @@ def read_edges(lines, nvertices):
              for v1, v2, value, *_ in (line.split()[:3] + [1]
                                        for line in lines)]
     v1s, v2s, values = zip(*lines)
+    values = np.array(values)
+    if values.size and np.all(values == values[0]):
+        values = np.lib.stride_tricks.as_strided(
+            values[0], (len(values), ), (0, ))
+        values.flags.writeable = False
     return sp.coo_matrix((values, (np.array(v1s) - 1, np.array(v2s) - 1)),
                          shape=(nvertices, nvertices))
 
@@ -49,9 +54,9 @@ def read_edges_list(lines, nvertices):
         indices += targets
     indptr += [len(indices)] * (nvertices - len(indptr) + 1)
     indices = np.array(indices, dtype=int) - 1
-    return sp.csr_matrix(
-        (np.ones(len(indices), dtype=np.int8), indices, indptr),
-        shape=(nvertices, nvertices))
+    data = np.lib.stride_tricks.as_strided(np.ones(1), (len(indices), ), (0, ))
+    data.flags.writeable = False
+    return sp.csr_matrix((data, indices, indptr), shape=(nvertices, nvertices))
 
 
 def read_pajek(path):


### PR DESCRIPTION
##### Issue

- Network Explorer crashed for graphs read from Pajek's edges lists, supported by the new reader. 

    This happened because the reader was smart enough to store edges as unsigned chars, which reduced memory usage by a factor of 8, but FR code in Cython expects doubles.

- Fixes #138. The bug was probably in networkx, which we no longer use, but it is also present in the current master. Pajek format is largely undocumented, hence supporting it requires a lot of guess work.

##### Description of changes

- This PR changes dtype of edges, returned by the reader, to double.
- It also stores edges of unweighted graphs with a sparse matrix in which `data` is written in a single `double` but with stride set to 0 to fake a constant array of required size without wasting memory.
- For #138, it properly treats indices.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
