### PR TITLE
Network File: Fix status line

### DIFF
--- a/orangecontrib/network/widgets/OWNxFile.py
+++ b/orangecontrib/network/widgets/OWNxFile.py
@@ -179,12 +179,12 @@ class OWNxFile(OWWidget):
         self.Outputs.network.send(self.network)
         self.Outputs.items.send(self.network.nodes)
 
-        n_edges = self.network.number_of_nodes()
-        n_nodes = self.network.number_of_edges()
-        summary = f"{n_edges} nodes, {n_nodes} edges"
+        n_nodes = self.network.number_of_nodes()
+        n_edges = self.network.number_of_edges()
+        summary = f"{n_nodes} / {n_edges}"
         details = \
             ('Directed' if self.network.edges[0].directed else 'Undirected') \
-            + f" network with {n_nodes} nodes and {n_edges} edges."
+            + f" network with\n{n_nodes} nodes and {n_edges} edges."
         self.info.set_output_summary(summary, details)
 
     def set_network_nodes(self):


### PR DESCRIPTION
##### Issue

Fixes #125.

##### Description of changes

This widget will always show an error, warning or info, so text like "123 nodes and 234 edges" stands no chance to fit in. I changed the summary to "123 / 234" (less too long) and kept the tooltip text.

I also fixed the mixed up numbers (Thanks, @matejklemen! LOL :).

##### Includes
- [X] Code changes