### PR TITLE
[FIX] Fix single-mode widget crashing

### DIFF
--- a/orangecontrib/network/network/twomode.py
+++ b/orangecontrib/network/network/twomode.py
@@ -44,10 +44,10 @@ def _dot_edges(normalization):
         new_edges = np.dot(edges, edges.T).tocoo()
         mask = np.logical_and(
             new_edges.row < new_edges.col,  new_edges.data != 0)
-        n = np.sum(mask)
+
         return sp.csr_matrix(
             (new_edges.data[mask], (new_edges.row[mask], new_edges.col[mask])),
-            shape=(n, n))
+            shape=new_edges.shape)
     return norm_dot
 
 

--- a/orangecontrib/network/tests/test_twomode.py
+++ b/orangecontrib/network/tests/test_twomode.py
@@ -158,24 +158,34 @@ class TestTwoMode(unittest.TestCase):
         )
 
     def test_to_single_mode(self):
-        def assert_edges(actual, expected):
-            self.assertEqual(len(actual), len(expected))
-            self.assertEqual(set(actual), set(expected))
-
         net = self._create_net(((0, 4, 1.), (4, 1, 5), (1, 5, 3),
                                 (2, 4, 4), (2, 5, 2), (3, 6, 6)))
 
         net1 = tm.to_single_mode(
             net,
             np.array([True] * 4 + [False] * 3),
-            np.array([False] * 3 + [True] * 4),
+            np.array([False] * 4 + [True] * 3),
             tm.NoWeights)
 
         np.testing.assert_equal(
             net1.edges[0].edges.todense(),
-            np.array([[0, 1, 1],
-                      [0, 0, 1],
-                      [0, 0, 0]])
+            np.array([[0, 1, 1, 0],
+                      [0, 0, 1, 0],
+                      [0, 0, 0, 0],
+                      [0, 0, 0, 0]])
+        )
+
+        net = self._create_net(((0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)), n=5)
+        net2 = tm.to_single_mode(
+            net,
+            np.array([True, False, False, True, False]),
+            np.array([False, False, True, False, True]),
+            tm.NoWeights
+        )
+        np.testing.assert_equal(
+            net2.edges[0].edges.todense(),
+            np.array([[0, 1],
+                      [0, 0]])
         )
 
 


### PR DESCRIPTION

##### Issue
Addresses #129 (I did not implement the second part of that issue, just fixed the crashing).

##### Description of changes
Multiple minor fixes:
- fixed the crashing;
- fixed an existing test: the masks for `mode_mask` and `conn_mask` were off. To my understanding, a node can either be "projected to", be used as a connection or none of these two ("ignored"), but it **can't** be both projected to and used as a connection;
- added a new test that would cause a crash before this fix.

The problem seemed to be that the adjacency matrix for the new (single-mode) network had the wrong shape - it was of shape `(#edges_in_projected_network, #edges_in_projected_network)`, when it should really be of dimension `(#projected_nodes, #projected_nodes)`.

Here's the visual form of the new test, maybe it will help when checking validity of the PR (network is being projected to brown/orange group via the green group).
![minimal_network](https://user-images.githubusercontent.com/17293960/65387720-394a4d80-dd4a-11e9-87c2-e489e3732a02.png)


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
