### PR TITLE
Fix Network Explorer crashing on empty network input

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -402,7 +402,7 @@ class OWNxExplorer(OWDataProjectionWidget):
         self.set_mark_mode(0)
         self.positions = None
 
-        if not graph or graph.number_of_nodes == 0:
+        if not graph or graph.number_of_nodes() == 0:
             set_graph_none()
             return
         if graph.number_of_nodes() + graph.number_of_edges() > 30000:

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -56,5 +56,11 @@ class TestOWNxExplorer(NetworkTest):
         self.assertSetEqual(set(self.widget.get_reachable([GENES["BLVRB"]])),
                             {GENES["BLVRB"], GENES["HMOX1"], GENES["BLVRA"]})
 
+    def test_empty_network(self):
+        net = Network([], [])
+        # should not crash
+        self.send_signal(self.widget.Inputs.network, net)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
When an empty network was fed into Network Explorer, it would crash due to zero division error in line
```self.edges_per_node = self.number_of_edges / self.number_of_nodes```.

Besides the example in the test, this can also be reproduced with the following workflow:  
**Network File** (last.fm) -> **Single Mode** (`best_tag`, connect `00s` by `(all others)`) -> **Network Explorer**.

##### Description of changes
The problem was actually that the check for a network having 0 nodes used `net.number_of_nodes` instead of `net.number_of_nodes()`. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
