### PR TITLE
Network analysis fixes/improvements

### DIFF
--- a/orangecontrib/network/network/generate.py
+++ b/orangecontrib/network/network/generate.py
@@ -52,9 +52,21 @@ def cycle(n):
     return np.arange(n), np.arange(1, n + 1) % n
 
 
-@from_dense
+@from_csr
 def complete(n):
-    return 1 - np.eye(n)
+    if n < 5_000:
+        return sp.triu(np.ones((n, n)), k=1, format="csr")
+
+    # manually construct sparse matrix elements to avoid storing a dense (n x n) matrix in memory
+    indptr = [0]
+    for n_above_diag in range(n - 1, 0, -1):
+        indptr.append(indptr[-1] + n_above_diag)
+    indptr.append(indptr[-1])
+    indptr = np.array(indptr)
+    indices = np.concatenate([np.arange(row, n) for row in range(1, n)])
+    data = np.ones(n * (n - 1) // 2)
+
+    return sp.csr_matrix((data, indices, indptr), shape=(n, n))
 
 
 @from_row_col

--- a/orangecontrib/network/tests/test_twomode.py
+++ b/orangecontrib/network/tests/test_twomode.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy.sparse as sp
 import orangecontrib.network.network.twomode as tm
 from orangecontrib.network import Network
+from orangecontrib.network.widgets.tests.utils import _create_net
 
 
 class TestTwoMode(unittest.TestCase):
@@ -73,14 +74,6 @@ class TestTwoMode(unittest.TestCase):
              (1, 2, 5 / 10 * 4 / 10 + 3 / 8 * 2 / 6))
         )
 
-    @staticmethod
-    def _create_net(edges, n=None):
-        row, col, data = zip(*edges)
-        if n is None:
-            n = max(*row, *col) + 1
-        return Network(np.arange(n),
-                       sp.coo_matrix((data, (row, col)), shape=(n, n)))
-
     def test_filtered_edges(self):
         def assert_edges(actual, expected):
             self.assertEqual(len(actual.data), len(expected))
@@ -88,8 +81,8 @@ class TestTwoMode(unittest.TestCase):
             self.assertEqual(
                 set(zip(actual.row, actual.col, actual.data)), set(expected))
 
-        net = self._create_net(((0, 4, 1.), (4, 1, 5), (1, 5, 3),
-                                (2, 4, 4), (2, 5, 2), (3, 6, 6)))
+        net = _create_net(((0, 4, 1.), (4, 1, 5), (1, 5, 3),
+                           (2, 4, 4), (2, 5, 2), (3, 6, 6)))
 
         # All edges
         assert_edges(
@@ -158,8 +151,8 @@ class TestTwoMode(unittest.TestCase):
         )
 
     def test_to_single_mode(self):
-        net = self._create_net(((0, 4, 1.), (4, 1, 5), (1, 5, 3),
-                                (2, 4, 4), (2, 5, 2), (3, 6, 6)))
+        net = _create_net(((0, 4, 1.), (4, 1, 5), (1, 5, 3),
+                           (2, 4, 4), (2, 5, 2), (3, 6, 6)))
 
         net1 = tm.to_single_mode(
             net,
@@ -175,7 +168,7 @@ class TestTwoMode(unittest.TestCase):
                       [0, 0, 0, 0]])
         )
 
-        net = self._create_net(((0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)), n=5)
+        net = _create_net(((0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)), n=5)
         net2 = tm.to_single_mode(
             net,
             np.array([True, False, False, True, False]),

--- a/orangecontrib/network/widgets/OWNxAnalysis.py
+++ b/orangecontrib/network/widgets/OWNxAnalysis.py
@@ -363,8 +363,10 @@ class OWNxAnalysis(widget.OWWidget):
         for name in to_stop:
             job = self.running_jobs[name]
             job.is_terminated = True
+            job.finished.disconnect()
             job.quit()
         for name in to_stop:
+            job = self.running_jobs[name]
             job.wait()
             setattr(self, "lbl_" + name, "terminated")
             del self.running_jobs[name]

--- a/orangecontrib/network/widgets/OWNxAnalysis.py
+++ b/orangecontrib/network/widgets/OWNxAnalysis.py
@@ -27,6 +27,23 @@ def shortest_paths_nan_diag(network):
     diag[:] = np.nan
     return paths
 
+
+def density(network):
+    n = network.number_of_nodes()
+    if n < 2:
+        return 0.0
+
+    num = network.number_of_edges()
+    if not network.edges[0].directed:
+        num *= 2
+    return num / (n * (n - 1))
+
+
+def avg_degree(network):
+    m = network.number_of_edges()
+    n = max(network.number_of_nodes(), 1)
+    return m / n if network.edges[0].directed else 2 * m / n
+
 # TODO: adapt betweenness_centrality and perhaps other statistics from
 # https://github.com/networkdynamics/zenlib/blob/master/src/zen/algorithms/centrality.pyx
 
@@ -43,11 +60,8 @@ METHODS = (
 
     ("number_of_nodes", lambda n: n, "Number of nodes", GRAPHLEVEL),
     ("number_of_edges", lambda e: e, "Number of edges", GRAPHLEVEL),
-    ("average_degree",
-     lambda degrees: np.mean(degrees), "Average degree", GRAPHLEVEL),
-    ("density",
-     lambda n, e: 2 * (e - n + 1) / (n * (n - 3) + 2), # what if it's negative?! on last fm?!?!
-     "Density", GRAPHLEVEL),
+    ("average_degree", lambda network: avg_degree(network), "Average degree", GRAPHLEVEL),
+    ("density", lambda network: density(network), "Density", GRAPHLEVEL),
 
     ("shortest_paths", shortest_paths_nan_diag, "Shortest paths"),
     ("diameter",

--- a/orangecontrib/network/widgets/OWNxAnalysis.py
+++ b/orangecontrib/network/widgets/OWNxAnalysis.py
@@ -48,9 +48,6 @@ def avg_degree(network):
 # TODO: adapt betweenness_centrality and perhaps other statistics from
 # https://github.com/networkdynamics/zenlib/blob/master/src/zen/algorithms/centrality.pyx
 
-# TODO: Add a flag telling whether the statistics is valid for directed,
-# undirected or both (default); show valid statistics
-
 # TODO: Combo that lets the user set edge types to use (or all)
 
 # Order of this list also defines execution priority

--- a/orangecontrib/network/widgets/OWNxAnalysis.py
+++ b/orangecontrib/network/widgets/OWNxAnalysis.py
@@ -14,6 +14,7 @@ from Orange.widgets.widget import Input, Output, Msg
 from orangecontrib.network.network import Network
 
 NODELEVEL, GRAPHLEVEL, INTERNAL = range(3)
+UNDIRECTED, DIRECTED, GENERAL = range(3)
 
 ERRORED = object()
 TERMINATED = object()
@@ -56,59 +57,59 @@ def avg_degree(network):
 METHODS = (
     ("n", lambda network: network.number_of_nodes()),
     ("e", lambda network: network.number_of_edges()),
-    ("degrees", lambda network: network.degrees(), "Degree", NODELEVEL),
+    ("degrees", lambda network: network.degrees(), "Degree", NODELEVEL, GENERAL),
 
-    ("number_of_nodes", lambda n: n, "Number of nodes", GRAPHLEVEL),
-    ("number_of_edges", lambda e: e, "Number of edges", GRAPHLEVEL),
-    ("average_degree", lambda network: avg_degree(network), "Average degree", GRAPHLEVEL),
-    ("density", lambda network: density(network), "Density", GRAPHLEVEL),
+    ("number_of_nodes", lambda n: n, "Number of nodes", GRAPHLEVEL, GENERAL),
+    ("number_of_edges", lambda e: e, "Number of edges", GRAPHLEVEL, GENERAL),
+    ("average_degree", lambda network: avg_degree(network), "Average degree", GRAPHLEVEL, GENERAL),
+    ("density", lambda network: density(network), "Density", GRAPHLEVEL, GENERAL),
 
     ("shortest_paths", shortest_paths_nan_diag, "Shortest paths"),
     ("diameter",
-     lambda shortest_paths: np.nanmax(shortest_paths), "Diameter", GRAPHLEVEL),
+     lambda shortest_paths: np.nanmax(shortest_paths), "Diameter", GRAPHLEVEL, GENERAL),
     ("radius",
      lambda shortest_paths: np.nanmin(np.nanmax(shortest_paths, axis=1)),
-     "Radius", GRAPHLEVEL),
+     "Radius", GRAPHLEVEL, GENERAL),
     ("average_shortest_path_length",
      lambda shortest_paths: np.nanmean(shortest_paths),
-     "Average shortest path length", GRAPHLEVEL),
+     "Average shortest path length", GRAPHLEVEL, GENERAL),
 
     ("number_strongly_connected_components", lambda network:
          csgraph.connected_components(network.edges[0].edges, False)[0],
-         "Number of strongly connected components", GRAPHLEVEL),
+         "Number of strongly connected components", GRAPHLEVEL, DIRECTED),
     ("number_weakly_connected_components", lambda network:
          csgraph.connected_components(network.edges[0].edges, True)[0],
-         "Number of weakly connected components", GRAPHLEVEL),
+         "Number of weakly connected components", GRAPHLEVEL, DIRECTED),
 
-    ("in_degrees", lambda network: network.in_degrees(), "In-degree", NODELEVEL),
-    ("out_degrees", lambda network: network.out_degrees(), "Out-degree", NODELEVEL),
+    ("in_degrees", lambda network: network.in_degrees(), "In-degree", NODELEVEL, GENERAL),
+    ("out_degrees", lambda network: network.out_degrees(), "Out-degree", NODELEVEL, GENERAL),
     ("average_neighbour_degrees",
      lambda network, degrees: np.fromiter(
          (np.mean(degrees[network.neighbours(i)]) if degree else np.nan
           for i, degree in enumerate(degrees)),
          dtype=np.float, count=len(degrees)),
-     "Average neighbor degree", NODELEVEL),
+     "Average neighbor degree", NODELEVEL, GENERAL),
     ("degree_centrality",
      lambda degrees, n: n and degrees / (n - 1) if n > 1 else 0,
-     "Degree centrality", NODELEVEL),
+     "Degree centrality", NODELEVEL, GENERAL),
     ("in_degree_centrality",
      lambda in_degrees, n: in_degrees / (n - 1) if n > 1 else 0,
-     "In-degree centrality", NODELEVEL),
+     "In-degree centrality", NODELEVEL, GENERAL),
     ("out_degree_centrality",
      lambda out_degrees, n: out_degrees / (n - 1) if n > 1 else 0,
-     "Out-degree centrality", NODELEVEL),
+     "Out-degree centrality", NODELEVEL, GENERAL),
     ("closeness_centrality",
      lambda shortest_paths: 1 / np.nanmean(shortest_paths, axis=1),
-     "Closeness centrality", NODELEVEL)
+     "Closeness centrality", NODELEVEL, GENERAL)
 )
 
 MethodDefinition = namedtuple(
     "MethodDefinition",
-    ["name", "func", "label", "level", "args"])
+    ["name", "func", "label", "level", "edge_constraint", "args"])
 
 
 METHODS = {definition[0]:
-    MethodDefinition(*(definition + ("", None, "", INTERNAL)[len(definition):]),
+    MethodDefinition(*(definition + ("", None, "", INTERNAL, GENERAL)[len(definition):]),
                      inspect.getfullargspec(definition[1]).args)
     for definition in METHODS}
 
@@ -222,6 +223,7 @@ class OWNxAnalysis(widget.OWWidget):
         graph_indices = gui.createTabPage(tabs, "Graph-level indices")
         node_indices = gui.createTabPage(tabs, "Node-level indices")
 
+        self.method_cbs = {}
         for method in METHODS.values():
             if method.level == INTERNAL:
                 continue
@@ -230,10 +232,12 @@ class OWNxAnalysis(widget.OWWidget):
 
             box = gui.hBox(
                 node_indices if method.level == NODELEVEL else graph_indices)
-            gui.checkBox(
+            cb = gui.checkBox(
                 box, self, method.name, method.label,
                 callback=lambda attr=method.name: self.method_clicked(attr)
             )
+            self.method_cbs[method.name] = cb
+
             box.layout().addStretch(1)
             lbl = gui.label(box, self, f"%(lbl_{method.name})s")
             setattr(self, "tool_" + method.name, lbl)
@@ -246,8 +250,28 @@ class OWNxAnalysis(widget.OWWidget):
         self.cancel_job()
         self.graph = graph
 
+        allowed_edge_types = {GENERAL, DIRECTED, UNDIRECTED}
+        if graph is not None:
+            allowed_edge_types.remove(UNDIRECTED if self.graph.edges[0].directed else DIRECTED)
+
         self.known = {}
         for name in METHODS:
+            curr_method = METHODS[name]
+            if curr_method.level == INTERNAL:
+                continue
+
+            lbl_obj = getattr(self, "tool_{}".format(name))
+            cb_obj = self.method_cbs[name]
+
+            # disable/re-enable valid graph indices
+            if curr_method.edge_constraint not in allowed_edge_types:
+                lbl_obj.setDisabled(True)
+                cb_obj.setChecked(False)
+                cb_obj.setEnabled(False)
+            else:
+                lbl_obj.setDisabled(False)
+                cb_obj.setEnabled(True)
+
             setattr(self, f"lbl_{name}", "")
 
         if graph is not None:

--- a/orangecontrib/network/widgets/OWNxAnalysis.py
+++ b/orangecontrib/network/widgets/OWNxAnalysis.py
@@ -330,7 +330,7 @@ class OWNxAnalysis(widget.OWWidget):
         # This does not really work because functions called in those
         # threads do not observe the "is_terminated" flag and won't quit
         if name is None:
-            to_stop = [job.method.name for job in self.running_jobs]
+            to_stop = list(self.running_jobs.keys())
         elif name in self.running_jobs:
             to_stop = [name]
         else:

--- a/orangecontrib/network/widgets/OWNxAnalysis.py
+++ b/orangecontrib/network/widgets/OWNxAnalysis.py
@@ -419,14 +419,12 @@ class OWNxAnalysis(widget.OWWidget):
                 self.set_label_for(name)
 
     def send_report(self):
-        self.report_items(
-            items=[(method.label, f"{self.known[attr]:.4g}")
-             for attr, method in METHODS.items()
-             if method.level == GRAPHLEVEL
-             and getattr(self, attr)
-             and attr in self.known
-             and isinstance(self.known[attr], (int, float))]
-        )
+        self.report_items("", items=[(method.label, f"{self.known[attr]:.4g}")
+                                     for attr, method in METHODS.items()
+                                     if method.level == GRAPHLEVEL
+                                     and getattr(self, attr)
+                                     and attr in self.known
+                                     and isinstance(self.known[attr], (int, float))])
 
 
 def main():

--- a/orangecontrib/network/widgets/tests/test_OWNxAnalysis.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxAnalysis.py
@@ -1,0 +1,29 @@
+import unittest
+import scipy.sparse as sp
+
+from orangecontrib.network.network.base import Network, UndirectedEdges
+from orangecontrib.network.widgets.OWNxAnalysis import density, avg_degree
+from orangecontrib.network.widgets.tests.utils import NetworkTest, _create_net
+
+
+class TestOWNxAnalysis(NetworkTest):
+    def setUp(self):
+        self.small_undir = _create_net(((0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)), n=5)
+        self.small_dir = _create_net(((0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)), n=5, directed=True)
+        self.empty_net = Network([], UndirectedEdges(sp.coo_matrix((0, 0))))
+
+    def test_density(self):
+        self.assertAlmostEqual(density(self.small_dir), 0.2)
+        self.assertAlmostEqual(density(self.small_undir), 0.4)
+        # n = 0 and n = 1 should not cause division problems
+        self.assertAlmostEqual(density(self.empty_net), 0.0)
+        self.assertAlmostEqual(density(self.empty_net), 0.0)
+
+    def test_average_degree(self):
+        self.assertAlmostEqual(avg_degree(self.small_dir), 0.8)
+        self.assertAlmostEqual(avg_degree(self.small_undir), 1.6)
+        self.assertAlmostEqual(avg_degree(self.empty_net), 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/orangecontrib/network/widgets/tests/test_OWNxAnalysis.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxAnalysis.py
@@ -2,12 +2,13 @@ import unittest
 import scipy.sparse as sp
 
 from orangecontrib.network.network.base import Network, UndirectedEdges
-from orangecontrib.network.widgets.OWNxAnalysis import density, avg_degree
+from orangecontrib.network.widgets.OWNxAnalysis import density, avg_degree, OWNxAnalysis
 from orangecontrib.network.widgets.tests.utils import NetworkTest, _create_net
 
 
 class TestOWNxAnalysis(NetworkTest):
     def setUp(self):
+        self.widget = self.create_widget(OWNxAnalysis)
         self.small_undir = _create_net(((0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)), n=5)
         self.small_dir = _create_net(((0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)), n=5, directed=True)
         self.empty_net = Network([], UndirectedEdges(sp.coo_matrix((0, 0))))
@@ -23,6 +24,16 @@ class TestOWNxAnalysis(NetworkTest):
         self.assertAlmostEqual(avg_degree(self.small_dir), 0.8)
         self.assertAlmostEqual(avg_degree(self.small_undir), 1.6)
         self.assertAlmostEqual(avg_degree(self.empty_net), 0.0)
+
+    def test_show_valid_indices_by_graph_type(self):
+        """ Test that some statistics get disabled based on type of network on input """
+        self.send_signal(self.widget.Inputs.network, self.small_undir)
+        self.assertFalse(self.widget.method_cbs["number_strongly_connected_components"].isEnabled())
+        self.assertFalse(self.widget.method_cbs["number_weakly_connected_components"].isEnabled())
+
+        self.send_signal(self.widget.Inputs.network, self.small_dir)
+        self.assertTrue(self.widget.method_cbs["number_strongly_connected_components"].isEnabled())
+        self.assertTrue(self.widget.method_cbs["number_weakly_connected_components"].isEnabled())
 
 
 if __name__ == '__main__':

--- a/orangecontrib/network/widgets/tests/utils.py
+++ b/orangecontrib/network/widgets/tests/utils.py
@@ -1,10 +1,22 @@
 import os
+import numpy as np
+import scipy.sparse as sp
 
 import orangecontrib
 from Orange.data import Table
 
+from orangecontrib.network import Network
+from orangecontrib.network.network.base import DirectedEdges, UndirectedEdges
 from orangecontrib.network.widgets.OWNxFile import OWNxFile
 from orangewidget.tests.base import WidgetTest
+
+
+def _create_net(edges, n=None, directed=False):
+    edge_cons = DirectedEdges if directed else UndirectedEdges
+    row, col, data = zip(*edges)
+    if n is None:
+        n = max(*row, *col) + 1
+    return Network(np.arange(n), edge_cons(sp.coo_matrix((data, (row, col)), shape=(n, n))))
 
 
 class NetworkTest(WidgetTest):


### PR DESCRIPTION
##### Issue
A few minor fixes and QoL additions.

##### Description of changes
1. Change density and average degree to have different values based on network type (different formulas).
These were previously generally calculated, though they have different formulas based on network type.  

2. Automatically "shadow" network statistics that are not meant to be used with input network's type (e.g. strongly connected components for undirected networks).
Assigned "general" usability (both directed/undirected) by default, a few statistics were restricted to directed networks only.
  
3. Minor fix in `cancel_job(...)`: properties that don't exist for a `str` were mistakenly being called.

4. Fix crash when requesting report.
Report name was missing - it can be `""` (now), but it can't be unspecified in function call (before).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
