### PR TITLE
[FIX] Fix deprecation warnings and locally failing test

### DIFF
--- a/orangecontrib/network/network/base.py
+++ b/orangecontrib/network/network/base.py
@@ -183,11 +183,11 @@ def aggregate_over_edge_types(aggregate, arg_no=0):
         @wraps(f)
         def wrapper(graph, *args, **kwargs):
             if len(args) <= arg_no or args[arg_no] is None:
-                return aggregate(
+                return aggregate([
                     f(graph,
                       *args[:arg_no], edge_type, *args[arg_no + 1:],
                       **kwargs)
-                    for edge_type in range(len(graph.edges)))
+                    for edge_type in range(len(graph.edges))])
             else:
                 return f(graph, *args, **kwargs)
         return wrapper

--- a/orangecontrib/network/widgets/OWNxFile.py
+++ b/orangecontrib/network/widgets/OWNxFile.py
@@ -5,6 +5,7 @@ from traceback import format_exception_only
 
 import numpy as np
 
+from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QStyle, QSizePolicy, QFileDialog
 
 from Orange.data import Table, Domain, StringVariable
@@ -63,7 +64,7 @@ class OWNxFile(OWWidget):
         self.data = None
         self.net_index = 0
 
-        hb = gui.widgetBox(self.controlArea, orientation="horizontal")
+        hb = gui.widgetBox(self.controlArea, orientation=Qt.Horizontal)
         self.filecombo = gui.comboBox(
             hb, self, "net_index", callback=self.select_net_file,
             minimumWidth=250)

--- a/orangecontrib/network/widgets/OWNxFromDistances.py
+++ b/orangecontrib/network/widgets/OWNxFromDistances.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 
-from AnyQt.QtCore import QLineF, QSize
+from AnyQt.QtCore import QLineF, QSize, Qt
 import pyqtgraph as pg
 from PyQt5.QtWidgets import QGridLayout
 from scipy.sparse import csgraph
@@ -90,7 +90,7 @@ class OWNxFromDistances(widget.OWWidget):
 
     def addHistogramControls(self):
         boxGeneral = gui.widgetBox(self.controlArea, box="Edges")
-        ribg = gui.widgetBox(boxGeneral, None, orientation="horizontal", addSpace=False)
+        ribg = gui.widgetBox(boxGeneral, None, orientation=Qt.Horizontal, addSpace=False)
         self.spin_high = gui.doubleSpin(boxGeneral, self, 'spinUpperThreshold',
                                         0, float('inf'), 0.001, decimals=3,
                                         label='Distance threshold',
@@ -99,19 +99,19 @@ class OWNxFromDistances(widget.OWWidget):
                                         controlWidth=60)
         self.histogram.region.sigRegionChangeFinished.connect(self.spinboxFromHistogramRegion)
 
-        ribg = gui.widgetBox(boxGeneral, None, orientation="horizontal", addSpace=False)
+        ribg = gui.widgetBox(boxGeneral, None, orientation=Qt.Horizontal, addSpace=False)
 
         gui.doubleSpin(boxGeneral, self, "percentil", 0, 100, 0.1,
-                      label="Percentile", orientation='horizontal',
+                      label="Percentile", orientation=Qt.Horizontal,
                       callback=self.setPercentil,
                       callbackOnReturn=1, controlWidth=60)
 
-        hbox = gui.widgetBox(boxGeneral, orientation='horizontal')
+        hbox = gui.widgetBox(boxGeneral, orientation=Qt.Horizontal)
         knn_cb = gui.checkBox(hbox, self, 'include_knn',
                               label='Include closest neighbors',
                               callback=self.generateGraph)
         knn = gui.spin(hbox, self, "kNN", 1, 1000, 1,
-                       orientation='horizontal',
+                       orientation=Qt.Horizontal,
                        callback=self.generateGraph, callbackOnReturn=1, controlWidth=60)
         knn_cb.disables = [knn]
         knn_cb.makeConsistent()
@@ -145,7 +145,7 @@ class OWNxFromDistances(widget.OWWidget):
         ribg = gui.radioButtonsInBox(self.controlArea, self, "edge_weights",
                                      box="Edge weights",
                                      callback=self.generateGraph)
-        hb = gui.widgetBox(ribg, None, orientation="horizontal", addSpace=False)
+        hb = gui.widgetBox(ribg, None, orientation=Qt.Horizontal, addSpace=False)
         gui.appendRadioButton(ribg, "Proportional to distance", insertInto=hb)
         gui.appendRadioButton(ribg, "Inverted distance", insertInto=hb)
 

--- a/orangecontrib/network/widgets/tests/test_graphview.py
+++ b/orangecontrib/network/widgets/tests/test_graphview.py
@@ -6,7 +6,7 @@ from AnyQt.QtCore import QLineF
 from AnyQt.QtGui import QPen, QBrush, QColor
 
 from Orange.widgets.tests.base import GuiTest
-from ..graphview import PlotVarWidthCurveItem
+from orangecontrib.network.widgets.graphview import PlotVarWidthCurveItem
 
 class TestPlotVarWidthCurveItem(GuiTest):
     def line_to_tuple(self, line: QLineF):


### PR DESCRIPTION
##### Issue
Gets rid of deprecation warnings and fixes a (locally) failing test due to relative import.


##### Description of changes
- get rid of deprecation warnings from Orange's `gui` module: change values in `orientation=` argument from `str` to `Qt` objects  
- fix locally failing test in `test_graphview.py`: change relative import to absolute import  
- get rid of numpy's `FutureWarning`: Numpy decided to drop support for generator inputs (see https://github.com/numpy/numpy/pull/12280) to `np.stack` family of functions, so the current generator expression is turned into a list comprehension 


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
