### PR TITLE
Improve Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,45 @@
 language: python
-sudo: false
-dist: trusty
-python: "3.6"
+
+dist: xenial
+
+matrix:
+    include:
+#        - &python36
+#          python: '3.6'
+#          env: ORANGE="release"
+#        - &python37
+#          python: '3.7'
+#          env: ORANGE="release"
+        - &master
+          python: '3.7'
+          env: ORANGE="master"
 
 cache:
-    apt: true
-    pip: true
-    ccache: true
+    apt: true   # does not work for public repos
+    directories:
+        - $HOME/.cache/pip
+        - $HOME/.ccache
+        - $TRAVIS_BUILD_DIR/pyqt
+
+before_cache:   # prevent logs from caching
+    - rm -f $HOME/.cache/pip/log/debug.log
 
 before_install:
+    - source $TRAVIS_BUILD_DIR/.travis/util.sh
     - pip install -U setuptools pip wheel
     - pip install codecov
+    # Orange requires numpy>=1.16 but cannot update it itself?
+    - pip install -U numpy
+    - mkdir -p /home/travis/.local/share/Orange  # create orange app dir
 
 install:
-    - pip install PyQt5==5.9.2 AnyQt
-    - travis_wait pip install -e .
-    - pip install git+https://github.com/biolab/orange3.git
+    - source $TRAVIS_BUILD_DIR/.travis/install_orange.sh
+    - pip install sip pyqt5==5.11.*
+    - python setup.py develop   # assure version.py is present; required for imports
 
 script:
-    - catchsegv xvfb-run -a -s "-screen 0 1280x1024x24" coverage run setup.py test
+    - XVFBARGS="-screen 0 1280x1024x24"
+    - catchsegv xvfb-run -a -s "$XVFBARGS" coverage run setup.py test
 
 after_success:
     - codecov

--- a/.travis/install_orange.sh
+++ b/.travis/install_orange.sh
@@ -1,0 +1,20 @@
+# CommonMark changed their interface in 0.8.0. Because older
+# Orange is imcompatible with newer CommonMark, 
+# install the module manually so that it does not get installed.
+# Remove this when the minimum supported Orange is 3.16.
+pip install CommonMark==0.7.5
+
+if [ $ORANGE == "release" ]; then
+    echo "Orange: Skipping separate Orange install"
+    return 0
+fi
+
+if [ $ORANGE == "master" ]; then
+    echo "Orange: from git master"
+    pip install https://github.com/biolab/orange3/archive/master.zip
+    return $?;
+fi
+
+PACKAGE="orange3==$ORANGE"
+echo "Orange: installing version $PACKAGE"
+pip install $PACKAGE

--- a/.travis/util.sh
+++ b/.travis/util.sh
@@ -1,0 +1,14 @@
+
+foldable ()
+{
+    # As documented in:
+    # https://github.com/travis-ci/travis-ci/issues/2158#issuecomment-42726890
+    # https://github.com/travis-ci/travis-ci/issues/2285#issuecomment-42724719
+    local _id="$RANDOM$RANDOM$RANDOM"
+    echo "travis_fold:start:$_id"
+    echo "$*"
+    "$@"
+    local _estatus="$?"
+    echo "travis_fold:end:$_id"
+    return $_estatus
+}


### PR DESCRIPTION
Tests started failing in send_report. Unfixing Qt version didn't help. Copying the test configuration from text add-on does.