### PR TITLE
[ENH] Node2vec node embeddings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_install:
     # Orange requires numpy>=1.16 but cannot update it itself
     # matplotlib needs certifi>=2020.06.20 but cannot update it itself
     - pip install -U numpy certifi
+    - pip install --ignore-installed gensim
     - mkdir -p /home/travis/.local/share/Orange  # create orange app dir
 
 install:

--- a/orangecontrib/network/network/embeddings.py
+++ b/orangecontrib/network/network/embeddings.py
@@ -1,0 +1,249 @@
+import numpy as np
+from Orange.data import ContinuousVariable, Table, Domain
+from gensim.models import Word2Vec
+
+from orangecontrib.network.network.base import DirectedEdges
+
+
+def alias_preprocess(probas_dict):
+    """
+        Preprocessing step for alias sampling, which enables drawing samples in O(1).
+        Returns triple of equal-length lists: [0] contains candidates, [1] contains the probability
+        of selecting the candidates after a biased coin flip, [2] contains reference to the alternative choice
+        after the flip.
+
+        Arguments
+        ---------
+        probas_dict: dict
+            Keys are nodes/edges, values are their probabilities
+
+        Useful reference: http://www.keithschwarz.com/darts-dice-coins/ (see Vose's Alias Method)
+    """
+    num_items = len(probas_dict)
+    alias, prob = [None] * num_items, [None] * num_items
+    # hold unnormalized probabilities < and >= 1, respectively
+    small, large = [], []
+
+    items = []
+    working_probas = []
+    for i, (curr_item, proba) in enumerate(probas_dict.items()):
+        items.append(curr_item)
+        unnorm_proba = proba * num_items
+        working_probas.append(unnorm_proba)
+        if unnorm_proba < 1.0:
+            small.append((i, unnorm_proba))
+        else:
+            large.append((i, unnorm_proba))
+
+    while small and large:
+        curr_lower, p_lower = small.pop()
+        curr_greater, p_greater = large.pop()
+
+        prob[curr_lower] = p_lower
+        alias[curr_lower] = curr_greater
+
+        remaining_greater = (p_greater + p_lower) - 1.0
+        if remaining_greater < 1.0:
+            small.append((curr_greater, remaining_greater))
+        else:
+            large.append((curr_greater, remaining_greater))
+
+    while large:
+        curr_greater, p_greater = large.pop()
+        prob[curr_greater] = 1.0
+
+    # can only be non-empty at this point due to numerical instability
+    while small:
+        curr_lower, p_lower = small.pop()
+        prob[curr_lower] = 1.0
+
+    return items, prob, alias
+
+
+def alias_draw(candidates, prob, alias):
+    """ Single draw of alias sampling - first, perform uniform draw between candidates, then do a biased coin flip
+    to determine whether to keep the chosen candidate or take its alternative.
+
+    Arguments
+    ---------
+    candidates: list
+        Raw names of candidates
+    prob: list
+        Probabilities of choosing items in `candidates` during a biased coin flip
+    alias: list
+        Reference (indices that index `candidates`) to alternative candidates during a biased coin flip
+    """
+    bucket_id = np.random.randint(0, len(candidates))
+    rand_num = np.random.random()
+
+    if rand_num < prob[bucket_id]:
+        return candidates[bucket_id]
+    else:
+        return candidates[alias[bucket_id]]
+
+
+def normalize(probas, norm_const):
+    # either all weights 0 or some positive, some negative - use softmax
+    if norm_const == 0.0:
+        normed_probas = {}
+        for item, proba in probas.items():
+            new_proba = np.exp(proba)
+            normed_probas[item] = new_proba
+            norm_const += new_proba
+    else:
+        normed_probas = probas
+
+    return {neigh: w / norm_const for neigh, w in normed_probas.items()}
+
+
+class Node2Vec:
+    def __init__(self, p=0.8, q=0.7, walk_len=80, num_walks=10, emb_size=50, window_size=5, num_epochs=1, prefix=None):
+        self.p = p
+        self.q = q
+        self.walk_len = walk_len
+        self.num_walks = num_walks
+        self.emb_size = emb_size
+        self.window_size = window_size
+        self.num_epochs = num_epochs
+
+        self._node_probas = {}
+        self._edge_probas = {}
+        if prefix is not None and isinstance(prefix, str):
+            self.feature_prefix = prefix
+        else:
+            self.feature_prefix = "n2v"
+
+    def __call__(self, G):
+        if not G.edges:
+            raise ValueError("Network has no edges")
+
+        num_nodes = G.number_of_nodes()
+        nodes = np.arange(num_nodes)
+        # Node->node probas are needed for the initial step, when there's no previous edge to condition on
+        self._node_probas = self.setup_nodes(G, nodes)
+
+        edges_coo = G.edges[0].edges.tocoo(copy=False)
+        edges = np.column_stack((edges_coo.row, edges_coo.col))
+        self._edge_probas = self.setup_edges(G, edges)
+
+        walks = self._simulate_walks(G)
+        walks = [list(map(str, walk)) for walk in walks]
+
+        model = Word2Vec(walks, size=self.emb_size, window=self.window_size, min_count=0, sg=1, workers=4,
+                         iter=self.num_epochs)
+
+        items = G.nodes
+        new_attrs = {}
+        new_data = np.array([[] for _ in range(num_nodes)])
+        class_vars, meta_vars = [], []
+        class_data, meta_data = np.array([[] for _ in range(num_nodes)]), np.array([[] for _ in range(num_nodes)])
+        if isinstance(items, Table):
+            attrs_mask = []
+            for attr in items.domain.attributes:
+                attrs_mask.append(attr.name not in new_attrs)
+                new_attrs[attr.name] = new_attrs.get(attr.name, (len(new_attrs), attr))
+
+            new_data = items.X[:, np.array(attrs_mask, dtype=bool)]
+            class_vars, meta_vars = items.domain.class_vars, items.domain.metas
+            class_data, meta_data = items.Y, items.metas
+
+        # override existing continuous vars with same names
+        for i in range(self.emb_size):
+            new_name = "{}_{}".format(self.feature_prefix, i)
+            new_attrs[new_name] = (len(new_attrs), ContinuousVariable(new_name))
+
+        new_data = np.hstack((new_data, np.array([model.wv[str(curr_node)] for curr_node in nodes])))
+        ordered_attrs = [None] * len(new_attrs)
+        for idx, attr in new_attrs.values():
+            ordered_attrs[idx] = attr
+        new_domain = Domain(ordered_attrs, class_vars, meta_vars)
+        new_items = Table(new_domain, new_data, class_data, meta_data)
+        return new_items
+
+    def _single_walk(self, start_node):
+        # assumes node and edge probabilities have been computed
+        curr_walk = [start_node]
+
+        nodes, prob, alias = self._node_probas[start_node]
+        # isolated starting node
+        if not nodes:
+            return curr_walk
+        # initial step (no previous node to condition on)
+        prev_node, curr_node = start_node, alias_draw(nodes, prob, alias)
+        curr_walk.append(curr_node)
+
+        for _ in range(self.walk_len - 2):
+            edges, prob, alias = self._edge_probas[(prev_node, curr_node)]
+            if len(edges) == 0:
+                break
+
+            prev_node, curr_node = alias_draw(edges, prob, alias)
+            curr_walk.append(curr_node)
+
+        return curr_walk
+
+    def _simulate_walks(self, G):
+        # assumes node and edge probabilities have been computed
+        walks = []
+        nodes = np.arange(G.number_of_nodes())
+
+        for idx_walk in range(self.num_walks):
+            np.random.shuffle(nodes)
+            for curr_node in nodes:
+                walks.append(self._single_walk(start_node=curr_node))
+
+        return walks
+
+    def setup_nodes(self, G, nodes):
+        return {n: alias_preprocess(self.node_probas(G, n)) for n in nodes}
+
+    def node_probas(self, G, from_node):
+        probas = {}
+        norm_const = 0.0
+        edges = G.edges[0]
+        edges = edges.edges if isinstance(edges, DirectedEdges) else edges.twoway_edges
+
+        for neigh_node in G.outgoing(from_node):
+            edge_w = edges[from_node, neigh_node]
+            norm_const += edge_w
+            probas[neigh_node] = edge_w
+
+        probas = normalize(probas, norm_const)
+        return probas
+
+    def setup_edges(self, G, edges):
+        probas = {}
+        if isinstance(G.edges[0], DirectedEdges):
+            for u, v in edges:
+                probas[(u, v)] = alias_preprocess(self.edge_probas(G, u, v))
+        else:
+            for u, v in edges:
+                probas[(u, v)] = alias_preprocess(self.edge_probas(G, u, v))
+                probas[(v, u)] = alias_preprocess(self.edge_probas(G, v, u))
+        return probas
+
+    def edge_probas(self, G, u, v):
+        """ Compute transition probas from `v` to neighbors, taking into account that edge u->v was just traversed. """
+        probas = {}
+        norm_const = 0.0
+        edges = G.edges[0]
+        edges = edges.edges if isinstance(edges, DirectedEdges) else edges.twoway_edges
+
+        # for checking if edge exists
+        edges_coo = edges.tocoo(copy=False)
+        edges_coo = set(zip(edges_coo.row, edges_coo.col))
+
+        for neigh_of_dst in G.outgoing(v):
+            edge_w = edges[v, neigh_of_dst]
+            if neigh_of_dst == u:
+                edge_w = edge_w / self.p
+            elif (u, neigh_of_dst) in edges_coo:
+                edge_w = edge_w
+            else:
+                edge_w = edge_w / self.q
+
+            probas[(v, neigh_of_dst)] = edge_w
+            norm_const += edge_w
+
+        probas = normalize(probas, norm_const)
+        return probas

--- a/orangecontrib/network/network/embeddings.py
+++ b/orangecontrib/network/network/embeddings.py
@@ -97,7 +97,8 @@ def normalize(probas, norm_const):
 
 
 class Node2Vec:
-    def __init__(self, p=0.8, q=0.7, walk_len=80, num_walks=10, emb_size=50, window_size=5, num_epochs=1, prefix=None):
+    def __init__(self, p=0.8, q=0.7, walk_len=80, num_walks=10, emb_size=50, window_size=5, num_epochs=1, prefix=None,
+                 callbacks=()):
         self.p = p
         self.q = q
         self.walk_len = walk_len
@@ -105,6 +106,7 @@ class Node2Vec:
         self.emb_size = emb_size
         self.window_size = window_size
         self.num_epochs = num_epochs
+        self.callbacks = callbacks
 
         self._node_probas = {}
         self._edge_probas = {}
@@ -130,7 +132,7 @@ class Node2Vec:
         walks = [list(map(str, walk)) for walk in walks]
 
         model = Word2Vec(walks, size=self.emb_size, window=self.window_size, min_count=0, sg=1, workers=4,
-                         iter=self.num_epochs)
+                         iter=self.num_epochs, callbacks=self.callbacks)
 
         items = G.nodes
         new_attrs = {}

--- a/orangecontrib/network/tests/test_embeddings.py
+++ b/orangecontrib/network/tests/test_embeddings.py
@@ -1,0 +1,71 @@
+import unittest
+
+import numpy as np
+import scipy.sparse as sp
+from Orange.data import Table, ContinuousVariable, Domain
+
+from orangecontrib.network import Network
+from orangecontrib.network.network.base import DirectedEdges, UndirectedEdges
+from orangecontrib.network.network.embeddings import Node2Vec
+
+
+class TestEmbeddings(unittest.TestCase):
+    def setUp(self):
+        row, col, w = zip(*((1, 2, 1.0), (1, 3, 3.0), (2, 3, 1.0), (2, 6, 0.5), (3, 4, 1.0), (4, 5, 1.0), (4, 7, -1.0),
+                            (5, 6, 0.0), (6, 5, 0.1), (6, 2, 0.1)))
+        dir_edges = DirectedEdges(sp.csr_matrix((w, (row, col)), shape=(8, 8)))
+        self.toy_directed = Network(np.arange(8), dir_edges)
+
+        row, col, w = zip(*((1, 2, 1.0), (1, 3, 3.0), (2, 3, 1.0), (2, 6, 0.5), (3, 4, 1.0), (4, 5, 1.0), (4, 7, -1.0),
+                            (5, 6, 0.1)))
+        undir_edges = UndirectedEdges(sp.csr_matrix((w, (row, col)), shape=(8, 8)))
+        self.toy_undirected = Network(np.arange(8), undir_edges)
+
+    def test_node_probas(self):
+        """ Test that node probabilities get calculated correctly """
+        n2v = Node2Vec()
+        # nowhere to go from isolated node
+        self.assertEqual(len(n2v.node_probas(self.toy_directed, 0)), 0)
+        # should not have division by zero when weights of edges to neighbors sum to 0
+        self.assertDictEqual(n2v.node_probas(self.toy_directed, 5), {6: 1.0})
+        probas = n2v.node_probas(self.toy_directed, 4)
+        self.assertAlmostEqual(probas[5], 0.881, places=3)
+        self.assertAlmostEqual(probas[7], 0.119, places=3)
+
+        self.assertDictEqual(n2v.node_probas(self.toy_directed, 1), {2: 0.25, 3: 0.75})
+        self.assertDictEqual(n2v.node_probas(self.toy_undirected, 3), {1: 0.6, 2: 0.2, 4: 0.2})
+
+    def test_edge_probas(self):
+        """ Test that edge probabilities get calculated appropriately based on shortest distance between previous node
+            and next node (equations in 'Search bias' section of node2vec paper) """
+        n2v = Node2Vec(p=0.8, q=0.5)
+        edge_probas = n2v.edge_probas(self.toy_directed, 3, 4)
+        self.assertAlmostEqual(edge_probas[(4, 5)], 0.982, places=3)  # d_tx = 2
+        self.assertAlmostEqual(edge_probas[(4, 7)], 0.018, places=3)  # d_tx = 2
+        edge_probas = n2v.edge_probas(self.toy_directed, 1, 2)
+        self.assertAlmostEqual(edge_probas[(2, 3)], 0.5)  # d_tx = 1
+        edge_probas = n2v.edge_probas(self.toy_directed, 5, 6)
+        self.assertAlmostEqual(edge_probas[(6, 5)], 0.385, places=3)  # d_tx = 0
+
+        edge_probas = n2v.edge_probas(self.toy_undirected, 1, 2)
+        self.assertAlmostEqual(edge_probas[(2, 1)], 0.385, places=3)  # d_tx = 0
+        self.assertAlmostEqual(edge_probas[(2, 3)], 0.308, places=3)  # d_tx = 1
+        self.assertAlmostEqual(edge_probas[(2, 6)], 0.308, places=3)  # d_tx = 2
+
+    def test_call(self):
+        n2v = Node2Vec(num_walks=10, walk_len=80, emb_size=300)
+        embeddings = n2v(self.toy_directed)
+        self.assertEqual(embeddings.X.shape, (self.toy_directed.number_of_nodes(), 300))
+
+        # check that domain is extended and that the  existing attributes do not change places
+        empty = np.array([[] for _ in range(8)])
+        data = Table(Domain([ContinuousVariable("var1")]), np.array([[i] for i in range(8)]), empty, empty)
+        toy_net_with_data = Network(data, self.toy_directed.edges[0])
+        extended_data = n2v(toy_net_with_data)
+
+        self.assertEqual(extended_data.X.shape, (toy_net_with_data.number_of_nodes(), 1 + 300))
+        np.testing.assert_array_almost_equal(extended_data.X[:, 0], np.arange(8))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/orangecontrib/network/widgets/OWNxEmbeddings.py
+++ b/orangecontrib/network/widgets/OWNxEmbeddings.py
@@ -2,11 +2,12 @@ from AnyQt.QtCore import Qt, QThread
 from Orange.data import Table
 from Orange.widgets.widget import OWWidget
 from gensim.models.callbacks import CallbackAny2Vec
-from orangewidget import gui, settings, widget
+from orangewidget import gui, settings
 from orangewidget.utils.signals import Input, Output
 
 from orangecontrib.network import Network
-from orangecontrib.network.network import embeddings
+from orangecontrib.network.network import embeddings, readwrite
+from orangewidget.utils.widgetpreview import WidgetPreview
 
 SPIN_WIDTH = 75
 METHOD_NAMES = ["node2vec"]
@@ -146,21 +147,8 @@ class OWNxEmbedding(OWWidget):
 
 
 if __name__ == "__main__":
-    from AnyQt.QtWidgets import QApplication
-    a = QApplication([])
-    ow = OWNxEmbedding()
-    ow.show()
-
-    def set_network(data, id=None):
-        ow.set_network(data)
-
-    import OWNxFile
     from os.path import join, dirname
-    owFile = OWNxFile.OWNxFile()
-    owFile.Outputs.network.send = set_network
-    owFile.open_net_file(join(dirname(dirname(__file__)), "networks", "davis.net"))
-
-    a.exec_()
-    ow.saveSettings()
-    owFile.saveSettings()
+    davis = join(dirname(__file__), "..", "networks", "davis.net")
+    network = readwrite.read_pajek(davis)
+    WidgetPreview(OWNxEmbedding).run(network)
 

--- a/orangecontrib/network/widgets/OWNxEmbeddings.py
+++ b/orangecontrib/network/widgets/OWNxEmbeddings.py
@@ -1,0 +1,118 @@
+from AnyQt.QtCore import Qt
+from Orange.data import Table
+from Orange.widgets.widget import OWWidget
+from orangewidget import gui, settings
+from orangewidget.utils.signals import Input, Output
+
+from orangecontrib.network import Network
+from orangecontrib.network.network import embeddings
+
+SPIN_WIDTH = 75
+METHOD_NAMES = ["node2vec"]
+NODE2VEC = 0
+
+
+class OWNxEmbedding(OWWidget):
+    name = "Network Embeddings"
+    description = "Embed network elements"
+    icon = "icons/NetworkFile.svg"
+    priority = 6450
+
+    class Inputs:
+        network = Input("Network", Network, default=True)
+
+    class Outputs:
+        items = Output("Items", Table)
+
+    class Warning(OWWidget.Warning):
+        pass
+
+    class Error(OWWidget.Error):
+        pass
+
+    resizing_enabled = False
+    want_main_area = False
+
+    method = settings.Setting(NODE2VEC)
+
+    p = settings.Setting(1.0)
+    q = settings.Setting(1.0)
+    walk_len = settings.Setting(50)
+    num_walks = settings.Setting(10)
+    emb_size = settings.Setting(128)
+    window_size = settings.Setting(5)
+    num_epochs = settings.Setting(1)
+
+    auto_commit = settings.Setting(True)
+
+    def __init__(self):
+        super().__init__()
+        self.network = None
+        self.embedder = None
+
+        def commit():
+            return self.commit()
+
+        gui.comboBox(self.controlArea, self, "method", label="Method: ",
+                     items=[method for method in METHOD_NAMES], callback=commit)
+
+        box = gui.widgetBox(self.controlArea, "Method parameters")
+        gui.spin(box, self, "p", 0.0, 10.0, 0.1, label="Return parameter (p): ", spinType=float,
+                 controlWidth=SPIN_WIDTH, callback=commit)
+        gui.spin(box, self, "q", 0.0, 10.0, 0.1, label="In-out parameter (q): ", spinType=float,
+                 controlWidth=SPIN_WIDTH, callback=commit)
+        gui.spin(box, self, "walk_len", 1, 100_000, 1, label="Walk length: ",
+                 controlWidth=SPIN_WIDTH, callback=commit)
+        gui.spin(box, self, "num_walks", 1, 10_000, 1, label="Walks per node: ",
+                 controlWidth=SPIN_WIDTH, callback=commit)
+        gui.spin(box, self, "emb_size", 1, 10_000, 1, label="Embedding size: ",
+                 controlWidth=SPIN_WIDTH, callback=commit)
+        gui.spin(box, self, "window_size", 1, 20, 1, label="Context size: ",
+                 controlWidth=SPIN_WIDTH, callback=commit)
+        gui.spin(box, self, "num_epochs", 1, 100, 1, label="Number of epochs: ",
+                 controlWidth=SPIN_WIDTH, callback=commit)
+
+        self.info_label = gui.widgetLabel(self.controlArea, "")
+        gui.auto_commit(self.controlArea, self, "auto_commit", "Commit",
+                        checkbox_label="Auto-commit", orientation=Qt.Horizontal)
+        commit()
+
+    @Inputs.network
+    def set_network(self, net):
+        self.network = net
+        self.commit()
+
+    def commit(self):
+        self.info_label.setText("")
+
+        if self.network is None:
+            self.Outputs.items.send(None)
+            return
+
+        if self.method == NODE2VEC:
+            self.embedder = embeddings.Node2Vec(self.p, self.q, self.walk_len, self.num_walks,
+                                                self.emb_size, self.window_size, self.num_epochs)
+
+        output = self.embedder(self.network)
+        self.Outputs.items.send(output)
+
+
+if __name__ == "__main__":
+    from AnyQt.QtWidgets import QApplication
+    a = QApplication([])
+    ow = OWNxEmbedding()
+    ow.show()
+
+    def set_network(data, id=None):
+        ow.set_network(data)
+
+    import OWNxFile
+    from os.path import join, dirname
+    owFile = OWNxFile.OWNxFile()
+    owFile.Outputs.network.send = set_network
+    owFile.open_net_file(join(dirname(dirname(__file__)), "networks", "davis.net"))
+
+    a.exec_()
+    ow.saveSettings()
+    owFile.saveSettings()
+

--- a/orangecontrib/network/widgets/OWNxEmbeddings.py
+++ b/orangecontrib/network/widgets/OWNxEmbeddings.py
@@ -30,6 +30,9 @@ class ProgressBarUpdater(CallbackAny2Vec):
         self.num_epochs = num_epochs
 
     def on_epoch_begin(self, model):
+        if self.widget is None:
+            return
+
         self.widget.progressBarSet(100 * (self.curr_epoch / self.num_epochs))
 
     def on_epoch_end(self, model):
@@ -130,6 +133,8 @@ class OWNxEmbedding(OWWidget):
 
     def onDeleteWidget(self):
         if self._worker_thread is not None:
+            # prevent the callback from trying to access deleted widget object
+            self._progress_updater.widget = None
             self._worker_thread.finished.disconnect()
             self._worker_thread.quit()
         super().onDeleteWidget()

--- a/orangecontrib/network/widgets/OWNxEmbeddings.py
+++ b/orangecontrib/network/widgets/OWNxEmbeddings.py
@@ -138,6 +138,12 @@ class OWNxEmbedding(OWWidget):
         self.progressBarFinished()
         self.Outputs.items.send(output)
 
+    def onDeleteWidget(self):
+        if self._worker_thread is not None:
+            self._worker_thread.finished.disconnect()
+            self._worker_thread.quit()
+        super().onDeleteWidget()
+
 
 if __name__ == "__main__":
     from AnyQt.QtWidgets import QApplication

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ SETUP_REQUIRES = (
 INSTALL_REQUIRES = (
     'pyqtgraph>=0.9.10',
     'numpy>=1.8.0',
+    'gensim',
     'Orange3>=3.20'
 ),
 


### PR DESCRIPTION
##### Issue
Introduces a new widget (Network embeddings) and a method for embedding nodes into vectors, [node2vec](https://arxiv.org/abs/1607.00653).

The method (very briefly described) works in 2 steps:
1. Obtain sequences of random walks across the network. These walks are guided by two parameters, **p** and **q**.
2. Run word2vec on these sequences to obtain embeddings.

##### Known TODOs
The method and widget already work, but some things need to be improved. 
- [X] additional testing to verify node2vec works properly
- [ ] at least a basic example of use
- [ ] proper icon (currently it uses the same icon as `Network File`)

I'd appreciate any comments regarding the widget.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
