### PR TITLE
Handle missing values in single mode

### DIFF
--- a/orangecontrib/network/widgets/ownxsinglemode.py
+++ b/orangecontrib/network/widgets/ownxsinglemode.py
@@ -141,6 +141,7 @@ class OWNxSingleMode(OWWidget):
 
     def update_output(self):
         """Output the network on the output"""
+        self.Warning.ignoring_missing.clear()
         self.Error.same_values.clear()
         new_net = None
         if self.network is not None:
@@ -156,7 +157,6 @@ class OWNxSingleMode(OWWidget):
 
     def _mode_masks(self):
         """Return indices of nodes in the two modes"""
-        self.Warning.ignoring_missing.clear()
         data = self.network.nodes
         col_view = data.get_column_view(self.variable)[0]
         column = col_view.astype(int)

--- a/orangecontrib/network/widgets/ownxsinglemode.py
+++ b/orangecontrib/network/widgets/ownxsinglemode.py
@@ -1,5 +1,6 @@
 from itertools import chain
 
+import numpy as np
 from AnyQt.QtWidgets import QFormLayout
 
 from Orange.data import DiscreteVariable, Table
@@ -9,6 +10,7 @@ from Orange.widgets.settings import DomainContextHandler, ContextSetting, \
 from Orange.widgets.utils.itemmodels import VariableListModel
 from Orange.widgets.utils.signals import Output, Input
 from Orange.widgets.widget import OWWidget, Msg
+
 from orangecontrib.network import Network
 from orangecontrib.network.network import twomode
 
@@ -32,6 +34,9 @@ class OWNxSingleMode(OWWidget):
 
     class Outputs:
         network = Output("Network", Network)
+
+    class Warning(OWWidget.Warning):
+        ignoring_missing = Msg("Nodes with missing data are being ignored.")
 
     class Error(OWWidget.Error):
         no_data = Msg("Network has additional data.")
@@ -68,6 +73,7 @@ class OWNxSingleMode(OWWidget):
     def set_network(self, network):
         self.closeContext()
 
+        self.Warning.clear()
         self.Error.clear()
         if network is not None:
             if not isinstance(network.nodes, Table):
@@ -150,13 +156,21 @@ class OWNxSingleMode(OWWidget):
 
     def _mode_masks(self):
         """Return indices of nodes in the two modes"""
+        self.Warning.ignoring_missing.clear()
         data = self.network.nodes
-        column = data.get_column_view(self.variable)[0].astype(int)
+        col_view = data.get_column_view(self.variable)[0]
+        column = col_view.astype(int)
+        # Note: conversion required to handle empty (object) arrays
+        missing_mask = np.isnan(col_view.astype(float))
+        if np.any(missing_mask):
+            column[missing_mask] = -1
+            self.Warning.ignoring_missing()
+
         mode_mask = column == self.connect_value
         if self.connector_value:
             conn_mask = column == self.connector_value - 1
         else:
-            conn_mask = column != self.connect_value
+            conn_mask = np.logical_and(column != self.connect_value, np.logical_not(missing_mask))
         return mode_mask, conn_mask
 
     def _set_output_msg(self, out_network=None):

--- a/orangecontrib/network/widgets/tests/test_ownxsinglemode.py
+++ b/orangecontrib/network/widgets/tests/test_ownxsinglemode.py
@@ -329,6 +329,32 @@ class TestOWNxSingleMode(NetworkTest):
         self._set_graph(self.table)
         self.widget.send_report()
 
+    def test_missing_data(self):
+        widget = self.widget
+        network = self._read_network("davis.net")
+        num_total = len(network.nodes)
+        network.nodes.X[0, 1] = np.nan  # hide a node's role (= person in this case)
+        self.send_signal(widget.Inputs.network, network)
+
+        # Feature: role, Connect: person
+        widget.variable = network.nodes.domain.attributes[1]
+        widget.connect_value = 1
+        widget.connector_value = 1
+        widget.update_output()
+        self.assertTrue(widget.Warning.ignoring_missing.is_shown())
+        person_network = self.get_output(widget.Outputs.network)
+        num_persons = len(person_network.nodes)
+
+        # Feature: role, Connect: event
+        widget.connect_value = 0
+        widget.connector_value = 2
+        widget.update_output()
+        event_network = self.get_output(widget.Outputs.network)
+        num_events = len(event_network.nodes)
+
+        # Make sure the node with missing data is ignored for both modes
+        self.assertEqual(num_persons + num_events, num_total - 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/orangecontrib/network/widgets/tests/test_ownxsinglemode.py
+++ b/orangecontrib/network/widgets/tests/test_ownxsinglemode.py
@@ -71,12 +71,12 @@ class TestOWNxSingleMode(NetworkTest):
         self.assertFalse(widget.Error.no_categorical.is_shown())
         self.assertFalse(widget.Error.same_values.is_shown())
 
-        self._set_graph(Table(Domain([], [], [self.a, self.c])))
+        self._set_graph(Table.from_domain(Domain([], [], [self.a, self.c])))
         self.assertSequenceEqual(model, [self.a, self.c])
         self.assertIs(widget.variable, self.a)
 
     def test_no_single_valued_vars(self):
-        self._set_graph(Table(Domain([self.a, self.b, self.c, self.d])))
+        self._set_graph(Table.from_domain(Domain([self.a, self.b, self.c, self.d])))
 
     def test_show_errors(self):
         widget = self.widget
@@ -88,19 +88,19 @@ class TestOWNxSingleMode(NetworkTest):
         no_categorical = widget.Error.no_categorical.is_shown
         same_values = widget.Error.same_values.is_shown
 
-        self._set_graph(Table(Domain([a, b, c, d])))
+        self._set_graph(Table.from_domain(Domain([a, b, c, d])))
         self.assertSequenceEqual(model, [a, c])
         self.assertFalse(no_data())
         self.assertFalse(no_categorical())
         self.assertFalse(same_values())
 
-        self._set_graph(Table(Domain([b, d])))
+        self._set_graph(Table.from_domain(Domain([b, d])))
         self.assertSequenceEqual(model, [])
         self.assertFalse(no_data())
         self.assertTrue(no_categorical())
         self.assertFalse(same_values())
 
-        self._set_graph(Table(Domain([a, b, c, d])))
+        self._set_graph(Table.from_domain(Domain([a, b, c, d])))
         self.assertSequenceEqual(model, [a, c])
         self.assertFalse(no_data())
         self.assertFalse(no_categorical())
@@ -118,21 +118,21 @@ class TestOWNxSingleMode(NetworkTest):
         self.assertFalse(no_categorical())
         self.assertFalse(same_values())
 
-        self._set_graph(Table(Domain([a, b, c, d])))
+        self._set_graph(Table.from_domain(Domain([a, b, c, d])))
         widget.connector_value = widget.connect_value + 1
         self.send_signal(widget.Inputs.network, None)
         self.assertFalse(no_data())
         self.assertFalse(no_categorical())
         self.assertFalse(same_values())
 
-        self._set_graph(Table(Domain([a, b, c, d])))
+        self._set_graph(Table.from_domain(Domain([a, b, c, d])))
         widget.connector_value = widget.connect_value + 1
         cb_connector.activated[int].emit(widget.connector_value)
         self.assertFalse(no_data())
         self.assertFalse(no_categorical())
         self.assertTrue(same_values())
 
-        self._set_graph(Table(Domain([b, d])))
+        self._set_graph(Table.from_domain(Domain([b, d])))
         self.assertFalse(no_data())
         self.assertTrue(no_categorical())
         self.assertFalse(same_values())
@@ -143,7 +143,7 @@ class TestOWNxSingleMode(NetworkTest):
         cb_kept = widget.controls.connect_value
         a, c = self.a, self.c
 
-        self._set_graph(Table(Domain([a, c])))
+        self._set_graph(Table.from_domain(Domain([a, c])))
         self.assertEqual(len(cb_kept), 2)
         widget.update_output.assert_called()
         widget.update_output.reset_mock()
@@ -171,7 +171,7 @@ class TestOWNxSingleMode(NetworkTest):
 
         self.assertFalse(cb_connector.isEnabled())
 
-        self._set_graph(Table(Domain([a, c])))
+        self._set_graph(Table.from_domain(Domain([a, c])))
         self.assertFalse(cb_connector.isEnabled())
         self.assertEqual(widget.connector_value, 2)
 
@@ -197,7 +197,7 @@ class TestOWNxSingleMode(NetworkTest):
         send = widget.Outputs.network.send = Mock()
         update = widget.update_output = Mock(side_effect=widget.update_output)
 
-        self._set_graph(Table(Domain([self.c])))
+        self._set_graph(Table.from_domain(Domain([self.c])))
         update.assert_called()
         update.reset_mock()
         send.assert_called()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #110 


##### Description of changes
Assigns a local "mode" -1 to nodes whose connection variable values are missing, so that it doesn't match any possible value (since categorical values are encoded with integers >= 0). A warning also gets displayed, telling the user that nodes with missing data are being ignored.

Unrelated to #110, I've also swapped some `Table(<domain>)` calls with `Table.from_domain(<domain>)` in tests due to deprecation warnings.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
