### PR TITLE
SingleMode tests: define DiscreteVariable.values as tuple

### DIFF
--- a/orangecontrib/network/widgets/tests/test_ownxsinglemode.py
+++ b/orangecontrib/network/widgets/tests/test_ownxsinglemode.py
@@ -28,7 +28,7 @@ class TestOWNxSingleMode(NetworkTest):
             [0, 0, 1]
         ]))
 
-        self.d = DiscreteVariable("d", values=["d0"])
+        self.d = DiscreteVariable("d", values=("d0", ))
 
     def _set_graph(self, data, edges=None):
         net = Network(


### PR DESCRIPTION
`Discrete.values` must be tuples.