### PR TITLE
OWNxFromDistances: fix crashes on certain inputs

### DIFF
--- a/orangecontrib/network/widgets/tests/test_OWNxFromDistances.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxFromDistances.py
@@ -31,6 +31,26 @@ class TestOWNxFromDistances(WidgetTest):
         self.assertTrue(net)
         self.assertEqual(net.number_of_nodes(), 36)
 
+    def test_no_crash_on_zero_distance(self):
+        """ Test that minimum distance 0 does not make the widget automatically set the distance threshold under 0,
+        causing no nodes to satisfy condition"""
+        dist = Euclidean(self.data, axis=1)
+
+        self.widget.percentil = 100.0
+        self.send_signal(self.widget.Inputs.distances, dist)
+        net = self.get_output(self.widget.Outputs.network)
+        self.assertTrue(net)
+        self.assertEqual(net.number_of_nodes(), len(self.data))
+
+    def test_no_crash_on_single_instance(self):
+        """Test that single instance does not crash widget due to distance matrix having no valid distances"""
+        dist = Euclidean(self.data[:1], axis=1)
+
+        self.send_signal(self.widget.Inputs.distances, dist)
+        net = self.get_output(self.widget.Outputs.network)
+        self.assertTrue(net)
+        self.assertEqual(net.number_of_nodes(), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #161 and some other minor problems.


##### Description of changes
The issue in #161 was due to not being able to infer a sensible distance threshold automatically because a distance matrix for 1 row contains only the self-distance, which is ignored when determining this threshold. The solution is to manually set the threshold to 0 in that case.

The second issue was that typing in 100. percentile would make the widget crash, due to the index corresponding to 100th percentile being out of bounds by 1 (`table[len(table)]`). I have changed the percentiles a bit so that the 0th and 100th percentile get mapped to some valid percentiles, corresponding to min and max.

The third issue (which was mostly possible due to 100th percentile being taken as valid) was that the distance threshold would automatically be set below 0 when the minimum distance was 0 and the maximum distance was "high enough".
The problem was in this line, which (as far as I could figure out) sets the distance threshold in a way that the resulting network contains mostly isolated nodes, so that the user's computer doesn't blow up when opening the widget. 
```python
self.spinUpperThreshold = low - (0.03 * (upp - low))
```
The solution is to clip it so that it stays >= 0.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
