### PR TITLE
Network Explorer: if more than one node selected, show weights only for edges between selected nodes

### DIFF
--- a/orangecontrib/network/widgets/graphview.py
+++ b/orangecontrib/network/widgets/graphview.py
@@ -215,7 +215,11 @@ class GraphView(OWScatterPlotBase):
         srcs, dests, weights = edges.row, edges.col, edges.data
         if self.label_selected_edges:
             selected = self._selected_and_marked()
-            selected_edges = selected[srcs] | selected[dests]
+            num_selected = np.sum(selected)
+            if num_selected >= 2:
+                selected_edges = selected[srcs] & selected[dests]
+            else:
+                selected_edges = selected[srcs] | selected[dests]
             srcs = srcs[selected_edges]
             dests = dests[selected_edges]
             weights = weights[selected_edges]
@@ -291,6 +295,7 @@ class GraphView(OWScatterPlotBase):
             self.scatterplot_marked.setZValue(-5)
             self.plot_widget.addItem(self.scatterplot_marked)
 
+        self.update_edge_labels()
         marked = self.master.get_marked_nodes()
         if marked is None:
             self.scatterplot_marked.setData([], [])

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -61,6 +61,23 @@ class TestOWNxExplorer(NetworkTest):
         # should not crash
         self.send_signal(self.widget.Inputs.network, net)
 
+    def test_edge_weights(self):
+        self.send_signal(self.widget.Inputs.network, self._read_network("davis.net"))
+        self.widget.graph.show_edge_weights = True
+
+        # Mark nodes with many connections (multiple): should show the weights for edges between marked nodes only
+        self.widget.mark_min_conn = 8
+        self.widget.set_mark_mode(8)
+        self.assertEqual(len(self.widget.graph.edge_labels), 12)
+
+        # Reset to default (no selection) and check that the labels disappear
+        self.widget.set_mark_mode(0)
+        self.assertEqual(len(self.widget.graph.edge_labels), 0)
+
+        # Mark nodes with most connections (single): should show all its edges' weights
+        self.widget.set_mark_mode(9)
+        self.assertEqual(len(self.widget.graph.edge_labels), 14)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implements #145 and fixes edge weight display when using mark criteria in Network Explorer.
If a single node is selected, current behaviour is used. Otherwise, show edge weights only between selected nodes.
Additionally, when using mark criteria (e.g. `Mark nodes with many connections`), it would sometimes not show edge weights - for example, if `Show edge weights` was already checked before.

##### Description of changes
1. If more than one node is selected, a check is performed to select only those edges where both the source and target are marked.
2. When updating marked nodes, `update_edge_labels()` also gets called now.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
