### PR TITLE
OWNxExplorer: automatically highlight input network subset

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -375,7 +375,6 @@ class OWNxExplorer(OWDataProjectionWidget):
     @Inputs.node_subset
     def set_node_subset(self, data):
         super().set_subset_data(data)
-        super()._handle_subset_data()
 
     @Inputs.node_distances
     def set_items_distance_matrix(self, matrix):
@@ -490,6 +489,7 @@ class OWNxExplorer(OWDataProjectionWidget):
 
         self.stop_optimization_and_wait()
         set_actual_data()
+        super()._handle_subset_data()
         if self.positions is None:
             set_actual_edges()
             self.set_random_positions()

--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -375,6 +375,7 @@ class OWNxExplorer(OWDataProjectionWidget):
     @Inputs.node_subset
     def set_node_subset(self, data):
         super().set_subset_data(data)
+        super()._handle_subset_data()
 
     @Inputs.node_distances
     def set_items_distance_matrix(self, matrix):

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -15,6 +15,9 @@ class TestOWNxExplorer(NetworkTest):
         self.network = self._read_network("lastfm.net")
         self.data = self._read_items("lastfm.tab")
 
+        self.davis_net = self._read_network("davis.net")
+        self.davis_data = self._read_items("davis.tsv")
+
     def test_minimum_size(self):
         # Disable this test from the base test class
         pass
@@ -62,7 +65,7 @@ class TestOWNxExplorer(NetworkTest):
         self.send_signal(self.widget.Inputs.network, net)
 
     def test_edge_weights(self):
-        self.send_signal(self.widget.Inputs.network, self._read_network("davis.net"))
+        self.send_signal(self.widget.Inputs.network, self.davis_net)
         self.widget.graph.show_edge_weights = True
 
         # Mark nodes with many connections (multiple): should show the weights for edges between marked nodes only
@@ -77,6 +80,21 @@ class TestOWNxExplorer(NetworkTest):
         # Mark nodes with most connections (single): should show all its edges' weights
         self.widget.set_mark_mode(9)
         self.assertEqual(len(self.widget.graph.edge_labels), 14)
+
+    def test_input_subset(self):
+        self.send_signal(self.widget.Inputs.network, self.davis_net)
+        self.send_signal(self.widget.Inputs.node_data, self.davis_data)
+        sub_mask = self.widget.get_subset_mask()
+        self.assertIsNone(sub_mask)
+
+        self.send_signal(self.widget.Inputs.node_subset, self.davis_data[:3])
+        sub_mask = self.widget.get_subset_mask()
+        num_subset_nodes = np.sum(sub_mask)
+        self.assertEqual(num_subset_nodes, 3)
+
+        self.send_signal(self.widget.Inputs.node_subset, None)
+        sub_mask = self.widget.get_subset_mask()
+        self.assertIsNone(sub_mask)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #158.
Fixes #144 (well, not directly, but implements the alternative proposed in #158, that solves this issue).

##### Description of changes
Subset data was not being registered properly. Calling `_handle_subset_data()` sets `subset_indices` properly and then the scatterplot-like highlighting starts working.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
