### PR TITLE
Network Explorer: Increase the limit for network size

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -405,7 +405,7 @@ class OWNxExplorer(OWDataProjectionWidget):
         if not graph or graph.number_of_nodes() == 0:
             set_graph_none()
             return
-        if graph.number_of_nodes() + graph.number_of_edges() > 30000:
+        if graph.number_of_nodes() + graph.number_of_edges() > 100000:
             set_graph_none(self.Error.network_too_large)
             return
         self.Error.clear()


### PR DESCRIPTION
##### Issue

Fixes #142. I tried
- a grid with 9801 vertices and 19404 edges,
- a 12d hypercube with 4096 vertices and 49152,

and both, FR and drawing, worked reasonably fast. Though you can't see anything, so I'd only push it to 100.000.

##### Includes
- [X] Code changes
