### PR TITLE
[FIX] Single Mode: Fix crash when variable value was removed

### DIFF
--- a/orangecontrib/network/widgets/ownxsinglemode.py
+++ b/orangecontrib/network/widgets/ownxsinglemode.py
@@ -23,7 +23,8 @@ class OWNxSingleMode(OWWidget):
 
     want_main_area = False
 
-    settingsHandler = DomainContextHandler(match_values=True)
+    settingsHandler = DomainContextHandler(
+        match_values=DomainContextHandler.MATCH_VALUES_ALL)
     variable = ContextSetting(None)
     connect_value = ContextSetting(0)
     connector_value = ContextSetting(0)


### PR DESCRIPTION
##### Issue

Fixes #151. 

Context handler's `match_values` flag was incorrectly set to `True` (which equaled 1, which equaled `MATCH_VALUES_CLASS`) instead of to `MATCH_VALUES_ALL`).

##### Includes
- [X] Code changes