### PR TITLE
Network File: Avoid resolving requirements in search for entry point

### DIFF
--- a/orangecontrib/network/widgets/OWNxFile.py
+++ b/orangecontrib/network/widgets/OWNxFile.py
@@ -1,6 +1,5 @@
 from os import path
 from itertools import product
-from pkg_resources import load_entry_point
 from traceback import format_exception_only
 
 import numpy as np
@@ -8,6 +7,7 @@ import numpy as np
 from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QStyle, QSizePolicy, QFileDialog
 
+from Orange.util import get_entry_point
 from Orange.data import Table, Domain, StringVariable
 from Orange.data.util import get_unique_names
 from Orange.widgets import gui, settings
@@ -52,6 +52,11 @@ class NxFileContextHandler(ContextHandler):
                 if var.name == context.label_variable:
                     widget.label_variable = var
                     break
+
+
+demos_path = next(
+    get_entry_point("Orange3-Network", "orange.data.io.search_paths", "network")
+    ())[1]
 
 
 class OWNxFile(OWWidget):
@@ -139,10 +144,7 @@ class OWNxFile(OWWidget):
     def browse_net_file(self, browse_demos=False):
         """user pressed the '...' button to manually select a file to load"""
         if browse_demos:
-            startfile = next(load_entry_point(
-                "Orange3-Network",
-                "orange.data.io.search_paths",
-                "network")())[1]
+            startfile = demos_path
         else:
             startfile = self.recentFiles[0] if self.recentFiles else '.'
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ INSTALL_REQUIRES = (
     'pyqtgraph>=0.9.10',
     'numpy>=1.8.0',
     'gensim',
-    'Orange3>=3.20'
+    'Orange3>=3.28'
 ),
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
##### Issue

Fixes #187.

Requires https://github.com/biolab/orange3/pull/5238.

The problem described in #187 occurs if the environment is inconsistent. This should only happen on developers' machines and not in properly installed Orange.

##### Description of changes

Call `Orange.util.get_entry_point`, which skips tests.

##### Includes
- [X] Code changes