### PR TITLE
Add tests for Network Groups

### DIFF
--- a/orangecontrib/network/widgets/OWNxGroups.py
+++ b/orangecontrib/network/widgets/OWNxGroups.py
@@ -231,24 +231,15 @@ class OWNxGroups(OWWidget):
 
 
 def main():
+    from orangecontrib.network.network.readwrite import read_pajek
     from os.path import join, dirname
-    from AnyQt.QtWidgets import QApplication
-    from orangecontrib.network.widgets.OWNxFile import OWNxFile
+    from orangewidget.utils.widgetpreview import WidgetPreview
 
-    app = QApplication([])
-    ow = OWNxGroups()
-    ow.show()
+    path = join(dirname(__file__), "..", "networks")
+    network = read_pajek(join(path, 'airtraffic.net'))
+    data = Table(join(path, 'airtraffic_items.tab'))
 
-    def set_network(data):
-        ow.set_network(data)
-
-    ow_file = OWNxFile()
-    ow_file.Outputs.network.send = set_network
-    ow_file.open_net_file(join(dirname(dirname(__file__)),
-                             "networks", "airtraffic.net"))
-    ow.handleNewSignals()
-    app.exec_()
-    ow.saveSettings()
+    WidgetPreview(OWNxGroups).run(set_network=network, set_data=data)
 
 
 if __name__ == "__main__":

--- a/orangecontrib/network/widgets/OWNxGroups.py
+++ b/orangecontrib/network/widgets/OWNxGroups.py
@@ -66,11 +66,13 @@ class OWNxGroups(OWWidget):
             self.controlArea, self, "weighting", box="Output weights",
             btnLabels=self.weight_labels, callback=self.__feature_combo_changed
         )
-        gui.separator(radios)
         gui.checkBox(
-            radios, self, "normalize", "Normalize by geometric mean",
-            callback=self.__feature_combo_changed
+            gui.indentedBox(radios),
+            self, "normalize", "Normalize by geometric mean",
+            callback=self.__normalization_changed
         )
+        self.controls.normalize.setEnabled(
+            self.weighting == self.WeightByWeights)
 
     def _set_input_label_text(self):
         if self.network is None:
@@ -93,6 +95,11 @@ class OWNxGroups(OWWidget):
             )
 
     def __feature_combo_changed(self):
+        self.controls.normalize.setEnabled(
+            self.weighting == self.WeightByWeights)
+        self.commit()
+
+    def __normalization_changed(self):
         self.commit()
 
     @Inputs.network

--- a/orangecontrib/network/widgets/OWNxGroups.py
+++ b/orangecontrib/network/widgets/OWNxGroups.py
@@ -230,7 +230,7 @@ class OWNxGroups(OWWidget):
                 ("Number of edges", self.out_edges)])
 
 
-def main():
+def main():  # pragma: no cover
     from orangecontrib.network.network.readwrite import read_pajek
     from os.path import join, dirname
     from orangewidget.utils.widgetpreview import WidgetPreview
@@ -242,5 +242,5 @@ def main():
     WidgetPreview(OWNxGroups).run(set_network=network, set_data=data)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/orangecontrib/network/widgets/tests/test_OWNxGroups.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxGroups.py
@@ -3,8 +3,9 @@ from unittest.mock import Mock
 from math import sqrt
 
 import numpy as np
+from scipy import sparse as sp
 
-from Orange.data import Table
+from Orange.data import Table, Domain, DiscreteVariable
 from Orange.widgets.tests.base import simulate
 
 from orangecontrib.network import Network
@@ -121,6 +122,56 @@ class TestOWNxGroups(NetworkTest):
 
         check.click()
         widget.commit.assert_called()
+
+    def test_weights(self):
+        label_var = DiscreteVariable("label", values=tuple("abcde"))
+        domain = Domain([label_var], [])
+        items = Table.from_numpy(domain, np.array([[0, 0, 1, 3, 4, 0, 1, 2, 4]]).T)
+        src, dst, weights = np.array(
+            [[0, 1, 5],
+             [1, 2, 4],
+             [3, 4, 6],
+             [0, 5, 3],
+             [1, 6, 1],
+             [2, 7, 2],
+             [3, 8, 8],
+             [4, 8, 7],
+             [5, 6, 2]]).T
+        edges = sp.coo_matrix((weights.astype(float), (src, dst)), shape=(9, 9))
+        network = Network(items, edges)
+        expected = np.zeros((5, 5), dtype=float)
+
+        widget = self.widget
+        buttons = widget.controls.weighting.buttons
+        self.send_signal(widget.Inputs.network, network)
+
+        buttons[widget.NoWeights].click()
+        groups = widget._map_network()
+        for i, j in [(0, 1), (1, 2), (3, 4)]:
+            expected[i, j] = 1
+        np.testing.assert_equal(groups.edges[0].edges.todense(), expected)
+
+        buttons[widget.WeightByDegrees].click()
+        groups = widget._map_network()
+        expected[0, 1] = 3
+        expected[1, 2] = 1
+        expected[3, 4] = 2
+        np.testing.assert_equal(groups.edges[0].edges.todense(), expected)
+
+        buttons[widget.WeightByWeights].click()
+        widget.normalize = False
+        groups = widget._map_network()
+        expected[0, 1] = 7
+        expected[1, 2] = 2
+        expected[3, 4] = 14
+        np.testing.assert_equal(groups.edges[0].edges.todense(), expected)
+
+        widget.normalize = True
+        groups = widget._map_network()
+        expected[0, 1] = 1 / sqrt(10 * 3) + 4 / sqrt(10 * 6) + 2 / sqrt(5 * 3)
+        expected[1, 2] = 2 / sqrt(6 * 2)
+        expected[3, 4] = 6 / sqrt(14 * 13) + 8 / sqrt(14 * 15)
+        np.testing.assert_equal(groups.edges[0].edges.todense(), expected)
 
 
 if __name__ == "__main__":

--- a/orangecontrib/network/widgets/tests/test_OWNxGroups.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxGroups.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import Mock
+from math import sqrt
 
 import numpy as np
 
@@ -93,6 +95,32 @@ class TestOWNxGroups(NetworkTest):
         self.widget.send_report()
         self.send_signal(self.widget.Inputs.network, None)
         self.widget.send_report()
+
+    def test_disable_normalize(self):
+        widget = self.widget
+        buttons = widget.controls.weighting.buttons
+        normalize = widget.controls.normalize
+
+        buttons[widget.NoWeights].click()
+        self.assertFalse(normalize.isEnabled())
+        buttons[widget.WeightByDegrees].click()
+        self.assertFalse(normalize.isEnabled())
+        buttons[widget.WeightByWeights].click()
+        self.assertTrue(normalize.isEnabled())
+        buttons[widget.WeightByDegrees].click()
+        self.assertFalse(normalize.isEnabled())
+
+    def test_commit_on_normalization_change(self):
+        widget = self.widget
+        check = widget.controls.normalize
+        widget.commit = Mock()
+
+        check.click()
+        widget.commit.assert_called()
+        widget.commit.reset_mock()
+
+        check.click()
+        widget.commit.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

Add tests for group weights (fixes #99).

Minor changes:
- indent checkbox for normalization that is applicable when selecting the last radio button; disables it when inapplicable.
- use the standard `WidgetPreview`.

##### Includes
- [X] Code changes
- [X] Tests
