### PR TITLE
Replace np.bool and with bool

### DIFF
--- a/orangecontrib/network/network/base.py
+++ b/orangecontrib/network/network/base.py
@@ -285,7 +285,7 @@ class Network:
             coordinates = self.coordinates[mask]
         else:
             coordinates = None
-        if mask.dtype is not np.bool:
+        if mask.dtype != bool:
             mask1 = np.full((self.number_of_nodes(),), False)
             mask1[mask] = True
             mask = mask1

--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -463,7 +463,7 @@ class OWNxExplorer(OWDataProjectionWidget):
 
             if self.data is not None:
                 # Replicate the necessary parts of set_data
-                self.valid_data = np.full(len(self.data), True, dtype=np.bool)
+                self.valid_data = np.full(len(self.data), True, dtype=bool)
                 self.init_attr_values()
                 self.openContext(self.data)
                 self.cb_class_density.setEnabled(self.can_draw_density())

--- a/orangecontrib/network/widgets/graphview.py
+++ b/orangecontrib/network/widgets/graphview.py
@@ -263,7 +263,7 @@ class GraphView(OWScatterPlotBase):
         if self.selection is None:
             selection = np.zeros(len(self.scatterplot_item.data), dtype=bool)
         else:
-            selection = np.array(self.selection, dtype=np.bool)
+            selection = np.array(self.selection, dtype=bool)
         marked = self.master.get_marked_nodes()
         if marked is not None:
             selection[marked] = 1


### PR DESCRIPTION
##### Issue

`numpy.bool` is [deprecated in Numpy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations), which results in numerous warnings like

```
DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

`bool` and `np.bool` are equal in the sense that `bool == np.bool` returns `True`.

##### Includes
- [X] Code changes
