### PR TITLE
Disable QT_QPA_PLATFORM=offscreen on Windows GH Action tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,11 +78,16 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade tox tox-pip-version
 
+      - name: Set environment variable
+        # this step sets QT_QPA_PLATFORM env which is required on Ubuntu and
+        # it is skipped on Windows - QLabel font issues
+        if: runner.os != 'Windows'
+        run: |
+          echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
+
       - name: Test with Tox
         run: |
           tox -e ${{ matrix.tox_env }}
-        env:
-          QT_QPA_PLATFORM: offscreen
 
       - name: Upload code coverage
         if: |


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Resolves #2, Closes #4 etc. -->
<!-- Or a short description, if the issue does not exist. -->
Tests fail because widget minimum size too wide on Windows https://github.com/biolab/orange3-network/pull/192

I found out that Qlablel's text which is 165px wide is more than 500px wide on Windows when `QT_QPA_PLATFORM=offscreen`. Also, the font family is different without `QT_QPA_PLATFORM=offscreen` `MS Shell Dlg 2` is used and with `QT_QPA_PLATFORM=offscreen` font-family is `Helvetica`. I tried to google it but cannot find a similar bug with `QT_QPA_PLATFORM=offscreen`. There are just some bugs reported with some fonts not accessible on Windows (which could be the reason for the different font but not the reason for too wide text). The height of the text is similar in both cases. 

##### Description of changes
Since I do not find the exact reason for the issue and `QT_QPA_PLATFORM=offscreen` is not required on Windows I suggest not using it on Windows.


##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
