### PR TITLE
Remove numpy and pyqtgraph from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,6 @@ SETUP_REQUIRES = (
 )
 
 INSTALL_REQUIRES = (
-    'pyqtgraph>=0.9.10',
-    'numpy>=1.8.0',
     'gensim',
     'Orange3>=3.28'
 ),


### PR DESCRIPTION
##### Issue

Orange already depends on them and the add-on will never depend on higher versions than Orange. Besides, these versions are never updated, so it's better to remove them.

Fixes #198.

##### Includes
- [X] Code changes