### PR TITLE
Updates for Orange 3.29

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -382,7 +382,12 @@ class OWNxExplorer(OWDataProjectionWidget):
 
     @Inputs.node_subset
     def set_node_subset(self, data):
-        super().set_subset_data(data)
+        # It would be better to call super, but this fails because super
+        # is decorated to set the partial summary for signal "Subset Data",
+        # which does not exist for this widget (OWNxExplorer.Inputs is not
+        # derived from OWDataProjectionWidget.Inputs in order to rename the
+        # signal)
+        self.subset_data = data
 
     @Inputs.node_distances
     def set_items_distance_matrix(self, matrix):

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ from setuptools import find_packages
 
 import numpy
 
-if sys.version_info < (3, 6):
-    sys.exit('Orange3-Network requires Python >= 3.6')
+if sys.version_info < (3, 7):
+    sys.exit('Orange3-Network requires Python >= 3.7')
 
 try:
     from Cython.Distutils.build_ext import new_build_ext as build_ext
@@ -75,8 +75,12 @@ SETUP_REQUIRES = (
 )
 
 INSTALL_REQUIRES = (
+    'anyqt',
     'gensim',
-    'Orange3>=3.28'
+    'Orange3>=3.29',
+    'orange-widget-base',
+    'scipy',
+    'scikit-learn',
 ),
 
 EXTRAS_REQUIRE = {

--- a/tox.ini
+++ b/tox.ini
@@ -26,14 +26,8 @@ setenv =
 deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
-    pyqtgraph==0.11.0
     oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.25.0
-    # Use newer canvas-core and widget-base to avoid segfaults on windows
-    oldest: orange-canvas-core==0.1.9 ; sys_platform != 'win32'
-    oldest: orange-canvas-core==0.1.15 ; sys_platform == 'win32'
-    oldest: orange-widget-base==4.5.0 ; sys_platform != 'win32'
-    oldest: orange-widget-base==4.9.0 ; sys_platform == 'win32'
+    oldest: orange3==3.29.0
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
     latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base


### PR DESCRIPTION
##### Issue

Crashes and failed tests due to incompatibility with Orange 3.29 and other dependencies.

##### Description of changes

- Unpin some dependencies and require Orange 3.29
- Fix a problem with summaries that appears because Network Explorers `Inputs` are not derived from `Inputs` of its parent class, but still calls the input handler for those inputs
- TBD: Fix parameters of `gensim`'s `Word2Vec`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
