### PR TITLE
[FIX] Network Clustering: Don't add labels to input network

### DIFF
--- a/orangecontrib/network/network/base.py
+++ b/orangecontrib/network/network/base.py
@@ -232,6 +232,10 @@ class Network:
         self.name = name
         self.coordinates = coordinates
 
+    def copy(self):
+        """Constructs a shallow copy of the network"""
+        return type(self)(self.nodes, self.edges, self.name, self.coordinates)
+
     def number_of_nodes(self):
         return len(self.nodes)
 

--- a/orangecontrib/network/widgets/OWNxClustering.py
+++ b/orangecontrib/network/widgets/OWNxClustering.py
@@ -83,10 +83,12 @@ class OWNxClustering(widget.OWWidget):
         # Tie a name for presenting clustering results to the widget instance
         if self.cluster_feature is None:
             self.cluster_feature = get_unique_names(domain, 'Cluster')
-        cd.add_results_to_items(self.net, labels, self.cluster_feature)
 
-        self.Outputs.items.send(self.net.nodes)
-        self.Outputs.network.send(self.net)
+        net = self.net.copy()
+        cd.add_results_to_items(net, labels, self.cluster_feature)
+
+        self.Outputs.items.send(net.nodes)
+        self.Outputs.network.send(net)
 
         nclusters = len(set(labels.values()))
         self.info.set_output_summary(nclusters, f"{nclusters} clusters")


### PR DESCRIPTION
##### Issue

Fixes #226.

##### Description of changes

Copy the network before adding labels.

No tests. Tests that a nonsense bug was removed are stupid. We test functionality, not non-functionality.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
