### PR TITLE
Change documentation theme to sphinx_rtd_theme and enable the documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -120,7 +120,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -149,7 +149,9 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['static']
+
+html_css_files = ['custom.css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
-Welcome to Orange3-Network's documentation!
-===========================================
+Orange3 Networks Add-on
+=======================
 
 Widgets
 -------

--- a/doc/static/custom.css
+++ b/doc/static/custom.css
@@ -1,0 +1,13 @@
+/* This CSS snippet makes that the navbar collapse on medium screen already */
+@media screen and (max-width: 950px){
+    .wy-nav-top{display:block}
+    .wy-nav-side{left:-300px}
+    .wy-nav-side.shift{width:85%;left:0}
+    .wy-side-scroll{width:auto}
+    .wy-side-nav-search{width:auto}
+    .wy-menu.wy-menu-vertical{width:auto}
+    .wy-nav-content-wrap{margin-left:0}
+    .wy-nav-content-wrap
+    .wy-nav-content{padding:1.618em}
+    .wy-nav-content-wrap.shift{position:fixed;min-width:100%;left:85%;top:0;height:100%;overflow:hidden}
+}

--- a/orangecontrib/network/widgets/__init__.py
+++ b/orangecontrib/network/widgets/__init__.py
@@ -8,6 +8,7 @@ Network visualization and analysis tools for Orange.
 """
 
 # Category description for the widget registry
+import sysconfig
 from orangecontrib.network import Network
 from orangewidget.utils.signals import summarize, PartialSummary
 
@@ -18,6 +19,26 @@ DESCRIPTION = "Network visualization and analysis tools for Orange."
 BACKGROUND = "#C0FF97"
 
 ICON = "icons/Category-Network.svg"
+
+# Location of widget help files.
+WIDGET_HELP_PATH = (
+    # Used for development.
+    # You still need to build help pages using
+    # make htmlhelp
+    # inside doc folder
+    ("{DEVELOP_ROOT}/doc/_build/htmlhelp/index.html", None),
+
+    # Documentation included in wheel
+    # Correct DATA_FILES entry is needed in setup.py and documentation has to be built
+    # before the wheel is created.
+    ("{}/help/orange3-network/index.html".format(sysconfig.get_path("data")), None),
+
+    # Online documentation url, used when the local documentation is available.
+    # Url should point to a page with a section Widgets. This section should
+    # includes links to documentation pages of each widget. Matching is
+    # performed by comparing link caption to widget name.
+    ("https://orange3-network.readthedocs.io/en/latest/", "")
+)
 
 
 @summarize.register(Network)

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,10 @@ PACKAGE_DATA = {
     'orangecontrib.network.tests': ['*']
 }
 
+DATA_FILES = [
+    # Data files that will be installed outside site-packages folder
+]
+
 SETUP_REQUIRES = (
     'setuptools',
 )
@@ -94,6 +98,9 @@ EXTRAS_REQUIRE = {
     'test': (
         'coverage',
     ),
+    'doc': (
+        'sphinx', 'recommonmark', 'sphinx_rtd_theme'
+    ),
 }
 
 DEPENDENCY_LINKS = (
@@ -109,8 +116,9 @@ ENTRY_POINTS = {
     'orange.data.io.search_paths': (
         'network = orangecontrib.network:networks',
     ),
-    'orange.widgets': (
-        'Networks = orangecontrib.network.widgets',
+    # Register widget help
+    "orange.canvas.help": (
+        'html-index = orangecontrib.network.widgets:WIDGET_HELP_PATH',
     )
 }
 
@@ -140,6 +148,7 @@ def ext_modules():
         )
     ]
 
+
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration(None)
@@ -149,6 +158,20 @@ def configuration(parent_package='', top_path=None):
                        quiet=True)
     config.add_subpackage('orangecontrib.network')
     return config
+
+
+def include_documentation(local_dir, install_dir):
+    global DATA_FILES
+
+    doc_files = []
+    for dirpath, _, files in os.walk(local_dir):
+        doc_files.append(
+            (
+                dirpath.replace(local_dir, install_dir),
+                [os.path.join(dirpath, f) for f in files]
+            )
+        )
+    DATA_FILES.extend(doc_files)
 
 
 if __name__ == '__main__':
@@ -161,6 +184,8 @@ if __name__ == '__main__':
         # survive a `./setup egg_info` without numpy so pip can properly
         # query our install dependencies
         cmdclass["build_ext"] = build_ext_error
+
+    include_documentation('doc/_build/htmlhelp', 'help/orange3-network')
 
     setup(
         configuration=configuration,
@@ -178,6 +203,7 @@ if __name__ == '__main__':
         packages=PACKAGES,
         ext_modules=ext_modules(),
         package_data=PACKAGE_DATA,
+        data_files=DATA_FILES,
         setup_requires=SETUP_REQUIRES,
         install_requires=INSTALL_REQUIRES,
         extras_require=EXTRAS_REQUIRE,


### PR DESCRIPTION
The documentation for the Orange3-networks module was not working before since there were no entries for docs location.

AND

While ago we discussed that we will use the same documentation theme for add-ons. After some discussion, we decided on sphinx-rtd-theme. The alternative is Alabaster but its sidebar is not so readable and it breaks long addon names in two lines.

With this PR I am implementing the sphinx-rtd-theme. I also changed that the menu bar collapses on the medium screen already (before it collapsed on small screens). On the medium screen, the content column was narrow already and it works well for widget documentation in Orange since at the default Orange help window size the sidebar is collapsed.