### PR TITLE
Network Explorer: Fix drawing of unweighted networks with arcs

### DIFF
--- a/orangecontrib/network/widgets/graphview.py
+++ b/orangecontrib/network/widgets/graphview.py
@@ -137,7 +137,8 @@ class PlotVarWidthCurveItem(pg.PlotCurveItem):
         # This part is not so optimized because there can't be that many loops
         if np.any(arcs):
             xs, ys = self.xData[::2][arcs], self.yData[1::2][arcs]
-            sizes = self.sizes[::2][arcs] + w3[arcs]
+            sizes = self.sizes[::2][arcs]
+            sizes += w3 if isinstance(w3, float) else w3[arcs]
             # if radius of loop would be size, then distance betwween
             # vertex and loop centers would be
             # d = np.sqrt(size ** 2 - r ** 2 / 2) + r / np.sqrt(2) + r / 2


### PR DESCRIPTION
##### Issue

Fixes #229.

For unweighted networks, the widths are stored in a float rather than numpy array, and can't be indexed.

##### Description of changes

Distinguish between the two cases.

##### Includes
- [X] Code changes

No tests. This is in `PlotVarWidthCurveItem.paint` and thus rather untestable.