### PR TITLE
Save: Don't crash on unsupported format

### DIFF
--- a/orangecontrib/network/widgets/OWNxSave.py
+++ b/orangecontrib/network/widgets/OWNxSave.py
@@ -80,7 +80,7 @@ class OWNxSave(OWSaveBase):
             return
 
         self.Error.general_error.clear()
-        if self.data is None or not self.filename:
+        if self.data is None or not self.filename or self.writer is None:
             return
         try:
             net = self.data


### PR DESCRIPTION
##### Issue

As of https://github.com/biolab/orange3/pull/5560, `OWSaveBase.writer` can be `None`.

##### Description of changes

In this case, do not save. Error will be set in the base class.

This PR does not depend on https://github.com/biolab/orange3/pull/5560 and can be merged anytime.

The potential bug that it fixes currently cannot occur.

##### Includes
- [X] Code changes
