### PR TITLE
[MNT] Replace deprecated numpy type aliases

### DIFF
--- a/orangecontrib/network/tests/test_twomode.py
+++ b/orangecontrib/network/tests/test_twomode.py
@@ -17,7 +17,7 @@ class TestTwoMode(unittest.TestCase):
             for n1, n2, w in edges:
                 a2[n1, n2] = w
             np.testing.assert_almost_equal(a, a2)
-            self.assertEqual(a.dtype, np.float)
+            self.assertEqual(a.dtype, float)
 
         edges = sp.coo_matrix(
             ([1., 5, 3, 4, 2, 6], ([0, 1, 1, 2, 2, 3], [4, 4, 5, 4, 5, 6])),
@@ -77,7 +77,7 @@ class TestTwoMode(unittest.TestCase):
     def test_filtered_edges(self):
         def assert_edges(actual, expected):
             self.assertEqual(len(actual.data), len(expected))
-            self.assertEqual(actual.data.dtype, np.float)
+            self.assertEqual(actual.data.dtype, float)
             self.assertEqual(
                 set(zip(actual.row, actual.col, actual.data)), set(expected))
 

--- a/orangecontrib/network/widgets/OWNxAnalysis.py
+++ b/orangecontrib/network/widgets/OWNxAnalysis.py
@@ -84,7 +84,7 @@ METHODS = (
      lambda network, degrees: np.fromiter(
          (np.mean(degrees[network.neighbours(i)]) if degree else np.nan
           for i, degree in enumerate(degrees)),
-         dtype=np.float, count=len(degrees)),
+         dtype=float, count=len(degrees)),
      "Average neighbor degree", NODELEVEL, GENERAL),
     ("degree_centrality",
      lambda degrees, n: n and degrees / (n - 1) if n > 1 else 0,


### PR DESCRIPTION
##### Issue

`np.float` is deprecated and should replaced with `float` to avoid warnings (https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).

##### Includes
- [X] Code changes
