### PR TITLE
Documentation: enable building with html builder

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,8 @@ source_parsers = {'.md': CommonMarkParser}
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'recommonmark',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/orangecontrib/network/widgets/__init__.py
+++ b/orangecontrib/network/widgets/__init__.py
@@ -26,7 +26,7 @@ WIDGET_HELP_PATH = (
     # You still need to build help pages using
     # make htmlhelp
     # inside doc folder
-    ("{DEVELOP_ROOT}/doc/_build/htmlhelp/index.html", None),
+    ("{DEVELOP_ROOT}/doc/_build/html/index.html", None),
 
     # Documentation included in wheel
     # Correct DATA_FILES entry is needed in setup.py and documentation has to be built

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ if __name__ == '__main__':
         # query our install dependencies
         cmdclass["build_ext"] = build_ext_error
 
-    include_documentation('doc/_build/htmlhelp', 'help/orange3-network')
+    include_documentation('doc/_build/html', 'help/orange3-network')
 
     setup(
         configuration=configuration,


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In https://github.com/biolab/orange3-educational/pull/109 we changed the documentation theme to shpinx rtd theme. It was found out that it does not support htmlhelp builder. 

##### Description of changes
Since with this theme, it is not required to build the documentation with htmlhelp I am changing the setting such that they are compatible with html builder. From now on we build documentation with `make html` instead of `make htmlhelp`


##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
