### PR TITLE
Unlock tables

### DIFF
--- a/orangecontrib/network/widgets/OWNxFile.py
+++ b/orangecontrib/network/widgets/OWNxFile.py
@@ -310,7 +310,8 @@ class OWNxFile(OWWidget):
         domain = Domain(src_dom.attributes, src_dom.class_vars,
                         src_dom.metas + (label_attr, ))
         data = source.transform(domain)
-        data.metas[:, -1] = nodes
+        with data.unlocked(data.metas):
+            data.metas[:, -1] = nodes
         return data
 
     def _label_to_tabel(self):

--- a/orangecontrib/network/widgets/__init__.py
+++ b/orangecontrib/network/widgets/__init__.py
@@ -41,7 +41,7 @@ WIDGET_HELP_PATH = (
 )
 
 
-@summarize.register(Network)
+@summarize.register
 def summarize_(net: Network):
     n = net.number_of_nodes()
     if len(net.edges) == 1:

--- a/orangecontrib/network/widgets/tests/test_ownxsinglemode.py
+++ b/orangecontrib/network/widgets/tests/test_ownxsinglemode.py
@@ -333,7 +333,8 @@ class TestOWNxSingleMode(NetworkTest):
         widget = self.widget
         network = self._read_network("davis.net")
         num_total = len(network.nodes)
-        network.nodes.X[0, 1] = np.nan  # hide a node's role (= person in this case)
+        with network.nodes.unlocked(network.nodes.X):
+            network.nodes.X[0, 1] = np.nan  # hide a node's role (= person in this case)
         self.send_signal(widget.Inputs.network, network)
 
         # Feature: role, Connect: person

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import sys
 from setuptools import setup
 
 from distutils.command.build_ext import build_ext
@@ -10,9 +9,6 @@ from distutils.core import Extension
 from setuptools import find_packages
 
 import numpy
-
-if sys.version_info < (3, 7):
-    sys.exit('Orange3-Network requires Python >= 3.7')
 
 try:
     from Cython.Distutils.build_ext import new_build_ext as build_ext

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ SETUP_REQUIRES = (
 INSTALL_REQUIRES = (
     'anyqt',
     'gensim',
-    'Orange3>=3.29',
+    'Orange3>=3.31',
     'orange-widget-base',
     'scipy',
     'scikit-learn',

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ setenv =
 deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
-    oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.29.0
+    oldest: scikit-learn
+    oldest: orange3==3.31.0
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
     latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base


### PR DESCRIPTION
##### Issue

Orange 3.31 locks tables (in tests)

##### Description of changes

- Unlock table in File widget and in tests for single mode. 
- Require Orange 3.31
- Assume Python > 3.7

##### Includes
- [X] Code changes