### PR TITLE
Update build_wheels.yml - Publish only on tag

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -61,6 +61,7 @@ jobs:
     name:  Upload Release Assets
     needs: [build_wheels]
     runs-on: ubuntu-20.04
+    if: startsWith(github.ref, 'refs/tags')
 
     steps:
       - name: Download bdist files
@@ -83,6 +84,7 @@ jobs:
     name:  PyPI Publish
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-20.04
+    if: startsWith(github.ref, 'refs/tags')
 
     steps:
       - name: Download bdist files


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Resolves #2, Closes #4 etc. -->
<!-- Or a short description, if the issue does not exist. -->
build_wheels will always attempt to publish wheels when triggered with workflow_dispatch.

##### Description of changes
Skip publishing on manually run. Publish only on release (new tag).

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
