### PR TITLE
setup.py - Fix cython build and cleanup

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - name: Check out the repo


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Resolves #2, Closes #4 etc. -->
The network doesn't build successfully after Cython 3 release

##### Description of changes
Fixup build - use cythonize
Additional cleanup: 
- Remove try-except around Cython import since we have pyporoject.toml which makes sure that Cython is always installed.
- Remove the error that raises when no Cython or Numpy is present (same reason)
- Change keywords and classifiers to List since Tuple is not accepted anymore

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
