### PR TITLE
[CI] Wheels - Update wheels building

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -8,30 +8,57 @@ on:
   workflow_dispatch:
 
 jobs:
+  generate-wheels-matrix:
+    # Create a matrix of all architectures & versions to build.
+    # This enables the next step to run cibuildwheel in parallel.
+    # From https://iscinumpy.dev/post/cibuildwheel-2-10-0/#only-210
+    name: Generate wheels matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install cibuildwheel
+        # Nb. keep cibuildwheel version pin consistent with job below
+        run: pipx install cibuildwheel==2.14.1
+      - id: set-matrix
+        run: |
+          MATRIX=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux \
+              | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos \
+              | jq -nRc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows \
+              | jq -nRc '{"only": inputs, "os": "windows-latest"}'
+            } | jq -sc
+          )
+          echo "include=$MATRIX" >> $GITHUB_OUTPUT
+
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.only }}
+    needs: generate-wheels-matrix
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-
+        include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      # Used to host cibuildwheel
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.9.0
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_SKIP: "cp27-* cp35-* pp*"
+        uses: pypa/cibuildwheel@v2.14.1
+        with:
+          only: ${{ matrix.only }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
           name: bdist_files
@@ -41,10 +68,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Build sdist (pep517)
         run: |
@@ -52,7 +79,7 @@ jobs:
           python -m pep517.build -s .
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sdist_files
           path: dist/*.tar.gz
@@ -108,5 +135,3 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: downloads/
-          # repository_url: https://test.pypi.org/legacy/
-          # verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,18 @@
 [build-system]
 requires = ["setuptools", "wheel", "cython", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+# Restrict the set of builds to mirror the wheels available in Orange3.
+skip = ["cp36-*", "cp37-*", "pp*", "*-musllinux_*"]
+build-verbosity = 2
+test-requires = ["pyqt5", "pytest"]
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "aarch64"]
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ if __name__ == '__main__':
         ext_modules=cythonize(EXTENSIONS),
         package_data=PACKAGE_DATA,
         data_files=DATA_FILES,
+        python_requires=">=3.8",
         setup_requires=SETUP_REQUIRES,
         install_requires=INSTALL_REQUIRES,
         extras_require=EXTRAS_REQUIRE,


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Resolves #2, Closes #4 etc. -->
The network does not build wheels for Python>3.9, and it doesn't provide wheels for MacOS - arm 

##### Description of changes
Update wheel building to:
- build wheels in parallel
- build all wheels that also Orange3 offers
- move configuration in pyproject.toml
- some other minor updates

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
