### PR TITLE
Add pyqtgraph to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ INSTALL_REQUIRES = (
     'gensim',
     'Orange3>=3.34',
     'orange-widget-base',
+    'pyqtgraph',
     'scipy',
     'scikit-learn',
 ),


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Resolves #2, Closes #4 etc. -->
<!-- Or a short description, if the issue does not exist. -->
According to https://github.com/conda-forge/orange3-network-feedstock/pull/22, pyqtgraph is missing in dependencies.

##### Description of changes
Adding pyqtgraph to dependecies

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
