### PR TITLE
FR: Divide into double, not Py_ssize_t

### DIFF
--- a/orangecontrib/network/network/layout/_fr_layout.pyx
+++ b/orangecontrib/network/network/layout/_fr_layout.pyx
@@ -1,7 +1,6 @@
 #cython: boundscheck=False
 #cython: wraparound=False
 #cython: initializedcheck=False
-#cython: cdivision=True
 #cython: embedsignature=True
 #cython: infer_types=False
 #cython: language_level=3
@@ -70,7 +69,7 @@ cpdef void repulse_sampled(arr_f2_t pos, arr_i1_t sample,
         Py_ssize_t i, j, s
 
         Py_ssize_t sample_size = sample.shape[0]
-        Py_ssize_t inv_sample_ratio = n_nodes / sample_size
+        double inv_sample_ratio = n_nodes / sample_size
         double k2 = sqr(k)
 
     for i in range(n_nodes):
@@ -167,9 +166,6 @@ def fruchterman_reingold_step(arr_f2_t pos,
         Py_ssize_t row, col, i, j, d, s
         Py_ssize_t n_nodes = pos.shape[0]
         Py_ssize_t n_dim = pos.shape[1]
-
-        Py_ssize_t sample_size = sample.shape[0]
-        Py_ssize_t inv_sample_ratio = n_nodes / sample_size
 
     with nogil:
         disp[:, :] = 0

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
     {env:PYQT_PYPI_NAME:PyQt5}=={env:PYQT_PYPI_VERSION:5.15.*}
     {env:WEBENGINE_PYPI_NAME:PyQtWebEngine}=={env:WEBENGINE_PYPI_VERSION:5.15.*}
     oldest: orange3==3.34.0
+    oldest: pandas<2.1
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
##### Issue

- With `cdivision=true`, dividing two ints resulted in an `int`,
- and were also stored into `Py_ssize_t`,
- with the former also masking a division by zero,
- in a place where the division was unnecessary anyway.

Luckily, this probably didn't effect the algorithm a lot.
