### PR TITLE
Network Explorer: Add exact match by label

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -196,6 +196,10 @@ class OWNxExplorer(OWDataProjectionWidget):
                 return None
             return marker(np.char.array(labels), txt)
 
+        def mark_label_equals():
+            return _mark_by_labels(
+                lambda labels, txt: np.flatnonzero(labels.lower() == txt))
+
         def mark_label_starts():
             return _mark_by_labels(
                 lambda labels, txt: np.flatnonzero(labels.lower().startswith(txt)))
@@ -268,6 +272,7 @@ class OWNxExplorer(OWDataProjectionWidget):
 
         self.mark_criteria = [
             ("(Select criteria for marking)", None, lambda: np.zeros((0,))),
+            ("Mark node labelled as", text_line(), mark_label_equals),
             ("Mark nodes whose label starts with", text_line(), mark_label_starts),
             ("Mark nodes whose label contains", text_line(), mark_label_contains),
             ("Mark nodes whose data that contains", text_line(), mark_text),

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -79,7 +79,7 @@ class TestOWNxEplorerWithoutLayout(TestOWNxExplorer):
 
         # Mark nodes with many connections (multiple): should show the weights for edges between marked nodes only
         self.widget.mark_min_conn = 8
-        self.widget.set_mark_mode(8)
+        self.widget.set_mark_mode(9)
         self.assertEqual(len(self.widget.graph.edge_labels), 12)
 
         # Reset to default (no selection) and check that the labels disappear
@@ -87,7 +87,7 @@ class TestOWNxEplorerWithoutLayout(TestOWNxExplorer):
         self.assertEqual(len(self.widget.graph.edge_labels), 0)
 
         # Mark nodes with most connections (single): should show all its edges' weights
-        self.widget.set_mark_mode(9)
+        self.widget.set_mark_mode(10)
         self.assertEqual(len(self.widget.graph.edge_labels), 14)
 
     def test_input_subset(self):


### PR DESCRIPTION
##### Issue

Fixes #264.

##### Description of changes

Add match by exact label.

@ajdapretnar, if this works for you, feel free to merge. There will be no tests; this widget is what it is -- largely untested. Adding a new option at the beginning (changing the indices of all options) bothered only a single test. :(

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
