### PR TITLE
Release workflow - Inherit secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,3 +9,4 @@ jobs:
     uses: biolab/orange-ci-cd/.github/workflows/release.yml@master
     with:
       pure-python: false
+    secrets: inherit


### PR DESCRIPTION
##### Issue
Releasing using reusable workflows currently cannot use PyPI's Trusted Publishing. https://github.com/pypi/warehouse/issues/11096


##### Description of changes
We are moving back to secret for uploading.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
