### PR TITLE
Fix neighbors/outgoing/ingoing with weights=False

### DIFF
--- a/orangecontrib/network/network/base.py
+++ b/orangecontrib/network/network/base.py
@@ -51,8 +51,7 @@ class Edges:
         if not weights:
             return matrix.indices[fr:to]
         else:
-            return np.vstack(np.atleast_2d(matrix.indices[fr:to]),
-                             np.atleast_2d(matrix.data[fr:to]))
+            return matrix.indices[fr:to], matrix.data[fr:to]
 
     @staticmethod
     def _compute_degrees(edges, weighted):


### PR DESCRIPTION
##### Issue

Methods that return neighbours or ingoing or outgoing connections fail if `weights=True`. This code was obviously never used and never tested.

Network widgets are in dire need of unit tests. :(

##### Description of changes

A fix would be to add a pair of parentheses (`vstack` expects a tuple, not multiple arguments).

However, node indices are ints and weights are floats, so we should put them into the same array. Instead, the function now returns a tuple. Since nobody could have used the code, we need not care about backward compatibility.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
