### PR TITLE
Nx File: Fix Browse documentation datasets

### DIFF
--- a/orangecontrib/network/__init__.py
+++ b/orangecontrib/network/__init__.py
@@ -3,7 +3,7 @@ from importlib.resources import files, as_file
 def networks():
     path_in_package = files(__package__).joinpath('networks')
     with as_file(path_in_package) as dir_path:
-        yield ('', dir_path)
+        yield ('', str(dir_path))
 
 from .network import *
 


### PR DESCRIPTION
##### Issue

Fixes #279.

The bug was introduced https://github.com/biolab/orange3-network/pull/277/commits/d92c60393954067067239909b0dc23400a4485f4: unlike the obsolete code based on joining paths from pkg_resources, importlib.metadata gives a PosixPath object.

##### Description of changes

Cast PosixPath into a string.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
