### PR TITLE
[FIX]Network clustering: Fix auto-apply on enabling/disabling attenuation

### DIFF
--- a/orangecontrib/network/widgets/OWNxClustering.py
+++ b/orangecontrib/network/widgets/OWNxClustering.py
@@ -38,22 +38,23 @@ class OWNxClustering(widget.OWWidget):
         box = gui.vBox(self.controlArea, "Label Propagation")
         gui.spin(
             box, self, "iterations", 1, 100000, 1,
-            label="Max. iterations: ", callback=self.commit)
+            label="Max. iterations: ", callback=self.commit.deferred)
         gui.doubleSpin(box, self, "hop_attenuation", 0, 1, 0.01,
                        label="Apply hop attenuation: ",
-                       checked="attenuate", callback=self.commit,
-                       checkCallback=self.commit)
+                       checked="attenuate", callback=self.commit.deferred,
+                       checkCallback=self.commit.deferred)
         self.random_state = gui.checkBox(
             box, self, "use_random_state",
-            label="Replicable clustering", callback=self.commit)
+            label="Replicable clustering", callback=self.commit.deferred)
 
         gui.auto_apply(self.controlArea, self)
 
     @Inputs.network
     def set_network(self, net):
         self.net = net
-        self.commit()
+        self.commit.now()
 
+    @gui.deferred
     def commit(self):
         kwargs = {'iterations': self.iterations}
         if self.attenuate:

--- a/orangecontrib/network/widgets/OWNxClustering.py
+++ b/orangecontrib/network/widgets/OWNxClustering.py
@@ -41,7 +41,8 @@ class OWNxClustering(widget.OWWidget):
             label="Max. iterations: ", callback=self.commit)
         gui.doubleSpin(box, self, "hop_attenuation", 0, 1, 0.01,
                        label="Apply hop attenuation: ",
-                       checked="attenuate", callback=self.commit)
+                       checked="attenuate", callback=self.commit,
+                       checkCallback=self.commit)
         self.random_state = gui.checkBox(
             box, self, "use_random_state",
             label="Replicable clustering", callback=self.commit)

--- a/orangecontrib/network/widgets/tests/test_OWNxClustering.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxClustering.py
@@ -28,7 +28,7 @@ class TestOWNxClustering(NetworkTest):
 
         # Should not crash
         self.send_signal(self.widget.Inputs.network, graph)
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
 
         # There should be an additional cluster column
         output = self.get_output(self.widget.Outputs.network).nodes
@@ -39,11 +39,11 @@ class TestOWNxClustering(NetworkTest):
         self.widget.controls.use_random_state.setChecked(True)
 
         self.send_signal(self.widget.Inputs.network, network)
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
         res1 = self.get_output(self.widget.Outputs.network).nodes.metas
 
         self.send_signal(self.widget.Inputs.network, network)
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
         res2 = self.get_output(self.widget.Outputs.network).nodes.metas
 
         # Seeded rerun should give same clustering result
@@ -55,7 +55,7 @@ class TestOWNxClustering(NetworkTest):
 
         for _ in range(10):
             self.send_signal(self.widget.Inputs.network, network)
-            self.widget.unconditional_commit()
+            self.widget.commit.now()
 
         output = self.get_output(self.widget.Outputs.network).nodes
         # Multiple reruns should override the results instead of adding new feature every time


### PR DESCRIPTION
##### Issue

Fixes #283.

**Based on #284. Merge #284 first.**

##### Description of changes

Add a callback for the checkbox.

While at it, also replace the deprecated style of auto apply with the newer (as in "only a decade old" :) deferred commit.

##### Includes
- [X] Code changes