### PR TITLE
Updates for Python 3.14

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -15,6 +15,7 @@ network/community.py:
     def `label_propagation_hop_attenuation`:
         Undirected graph expected: false
 network/embeddings.py:
+    'gensim library is required to use Node2Vec embedding. ': false
     class `Node2Vec`:
         def `__init__`:
             n2v: false
@@ -281,6 +282,8 @@ widgets/OWNxEmbeddings.py:
             Network: Mreža
         class `Outputs`:
             Items: Elementi
+        class `Error`:
+            This widget requires gensim, which is unsupported in Python>=3.14.: Ta gradnik zahteva gensim, ki ni podprt v Pythonu >= 3.14.
         def `__init__`:
             p: false
             'Return parameter (p): ': 'Parameter vrnitve (p): '

--- a/orangecontrib/network/network/embeddings.py
+++ b/orangecontrib/network/network/embeddings.py
@@ -1,5 +1,9 @@
 import numpy as np
-import gensim
+try:
+    import gensim
+except:
+    raise ValueError("gensim library is required to use Node2Vec embedding. ")
+
 from gensim.models import Word2Vec
 from Orange.data import ContinuousVariable, Table, Domain
 

--- a/orangecontrib/network/tests/test_embeddings.py
+++ b/orangecontrib/network/tests/test_embeddings.py
@@ -1,4 +1,5 @@
 import unittest
+import datetime
 
 import numpy as np
 import scipy.sparse as sp
@@ -6,10 +7,25 @@ from Orange.data import Table, ContinuousVariable, Domain
 
 from orangecontrib.network import Network
 from orangecontrib.network.network.base import DirectedEdges, UndirectedEdges
-from orangecontrib.network.network.embeddings import Node2Vec
-
+try:
+    import gensim
+except ImportError:
+    gensim = None
+else:
+    from orangecontrib.network.network.embeddings import Node2Vec
 
 class TestEmbeddings(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if gensim is None:
+            if datetime.date.today() < datetime.date(2026, 6, 1):
+                raise unittest.SkipTest(
+                    "gensim library is required to run these tests.")
+            else:
+                raise RuntimeError(
+                    "Check whether gensim is supported "
+                    "and either update setup.py or change the above date.")
+
     def setUp(self):
         row, col, w = zip(*((1, 2, 1.0), (1, 3, 3.0), (2, 3, 1.0), (2, 6, 0.5), (3, 4, 1.0), (4, 5, 1.0), (4, 7, -1.0),
                             (5, 6, 0.0), (6, 5, 0.1), (6, 2, 0.1)))

--- a/orangecontrib/network/widgets/OWNxEmbeddings.py
+++ b/orangecontrib/network/widgets/OWNxEmbeddings.py
@@ -1,7 +1,12 @@
+try:
+    from gensim.models.callbacks import CallbackAny2Vec
+except ImportError:
+    raise ValueError("gensim library is required to use Node2Vec embedding. ")
+
+
 from AnyQt.QtCore import Qt, QThread
 from Orange.data import Table
 from Orange.widgets.widget import OWWidget
-from gensim.models.callbacks import CallbackAny2Vec
 from orangewidget import gui, settings
 from orangewidget.utils.signals import Input, Output
 

--- a/orangecontrib/network/widgets/OWNxEmbeddings.py
+++ b/orangecontrib/network/widgets/OWNxEmbeddings.py
@@ -1,7 +1,9 @@
+from orangewidget.widget import Msg
+
 try:
     from gensim.models.callbacks import CallbackAny2Vec
 except ImportError:
-    raise ValueError("gensim library is required to use Node2Vec embedding. ")
+    CallbackAny2Vec = None
 
 
 from AnyQt.QtCore import Qt, QThread
@@ -9,10 +11,12 @@ from Orange.data import Table
 from Orange.widgets.widget import OWWidget
 from orangewidget import gui, settings
 from orangewidget.utils.signals import Input, Output
+from orangewidget.utils.widgetpreview import WidgetPreview
 
 from orangecontrib.network import Network
-from orangecontrib.network.network import embeddings, readwrite
-from orangewidget.utils.widgetpreview import WidgetPreview
+from orangecontrib.network.network import readwrite
+if CallbackAny2Vec is not None:
+    from orangecontrib.network.network import embeddings
 
 
 class EmbedderThread(QThread):
@@ -28,7 +32,7 @@ class EmbedderThread(QThread):
         self.result = self.func()
 
 
-class ProgressBarUpdater(CallbackAny2Vec):
+class ProgressBarUpdater(CallbackAny2Vec or object):
     def __init__(self, widget, num_epochs):
         self.widget = widget
         self.curr_epoch = 0
@@ -55,6 +59,10 @@ class OWNxEmbedding(OWWidget):
 
     class Outputs:
         items = Output("Items", Table)
+
+    class Error(OWWidget.Error):
+        unsupported_gensim = Msg(
+            "This widget requires gensim, which is unsupported in Python>=3.14.")
 
     resizing_enabled = False
     want_main_area = False
@@ -100,12 +108,18 @@ class OWNxEmbedding(OWWidget):
                         checkbox_label="Auto-commit", orientation=Qt.Horizontal)
         commit()
 
+        if CallbackAny2Vec is None:
+            self.Error.unsupported_gensim()
+            self.controlArea.setDisabled(True)
+
     @Inputs.network
     def set_network(self, net):
         self.network = net
         self.commit()
 
     def commit(self):
+        if CallbackAny2Vec is None:
+            return
         self.Warning.clear()
 
         # cancel existing computation if running

--- a/orangecontrib/network/widgets/OWNxGroups.py
+++ b/orangecontrib/network/widgets/OWNxGroups.py
@@ -159,6 +159,7 @@ class OWNxGroups(OWWidget):
         else:
             weights = None
         if self.normalize:
+            weights = weights.copy() if weights is not None else None
             self._normalize_weights(row, col, weights)
         row, col = self._map_into_feature_values(row, col)
         return Network(

--- a/orangecontrib/network/widgets/tests/test_OWNxGroups.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxGroups.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import Mock
 from math import sqrt
+import datetime
 
 import numpy as np
 from scipy import sparse as sp
@@ -172,7 +173,6 @@ class TestOWNxGroups(NetworkTest):
         expected[1, 2] = 2 / sqrt(6 * 2)
         expected[3, 4] = 6 / sqrt(14 * 13) + 8 / sqrt(14 * 15)
         np.testing.assert_equal(groups.edges[0].edges.todense(), expected)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ SETUP_REQUIRES = (
 
 INSTALL_REQUIRES = (
     'anyqt',
-    'gensim',
+    'gensim; python_version < "3.14"',
     'Orange3>=3.38.1',
     'orange-widget-base',
     'pyqtgraph',


### PR DESCRIPTION
##### Issue

- Gensim doesn't work on Python 3.14
- Tests with Qt6 detect an error in the Groups widget that went undetected in Qt 5.
- 
##### Description of changes

- Skip installation on Python 3.14, and disable the widget. Add a test that will remind us to periodically check for gensim updates.
- Fix the error in Group: weights were modified in-place instead of in a copy.

##### Includes
- [X] Code changes
- [X] Tests
