### PR TITLE
Re-add gensim for Python 3.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ SETUP_REQUIRES = (
 
 INSTALL_REQUIRES = (
     'anyqt',
-    'gensim; python_version < "3.14"',
+    'gensim',
     'Orange3>=3.38.1',
     'orange-widget-base',
     'pyqtgraph',


### PR DESCRIPTION
A day after I changed setup.py to exclude gensim on Python 3.14, it appeared on conda-forge. Let's see if we can invite it back.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
