### PR TITLE
Network Explorer: Save network positions hint

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -88,6 +88,7 @@ network/readwrite.py:
     def `read_pajek`:
         def `check_has_vertices`:
             Vertices must be defined before edges or arcs: false
+        utf-8: false
         %: false
         *: false
         *network: false
@@ -103,6 +104,7 @@ network/readwrite.py:
         'This implementation of Pajek format does not support saving ': false
         networks with multiple edge types.: false
         wt: false
+        utf-8: false
         *Network "{network.name}"\n: false
     def `_write_vertices`:
         *Vertices\t{network.number_of_nodes()}\n: false

--- a/orangecontrib/network/network/readwrite.py
+++ b/orangecontrib/network/network/readwrite.py
@@ -99,7 +99,7 @@ def read_pajek(path):
         if labels is None:
             raise ValueError("Vertices must be defined before edges or arcs")
 
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         lines = [line.strip() for line in f]
     lines = np.array([line for line in lines if line and line[0] != "%"])
     part_starts = [(line_no, line)
@@ -153,7 +153,7 @@ def write_pajek(path, network, labels=None):
         raise TypeError(
             "This implementation of Pajek format does not support saving "
             "networks with multiple edge types.")
-    f = open(path, "wt") if isinstance(path, str) else path
+    f = open(path, "wt", encoding="utf-8") if isinstance(path, str) else path
     f.write(f'*Network "{network.name}"\n')
     _write_vertices(f, network, labels)
     if network.edges:

--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -1,3 +1,4 @@
+import hashlib
 from typing import Optional, Union
 
 import numpy as np
@@ -83,6 +84,9 @@ class OWNxExplorer(OWDataProjectionWidget, ConcurrentWidgetMixin):
     edge_width_variable_hint: Optional[str] = Setting(None, schema_only=True)
     edge_label_variable_hint: Optional[str] = Setting(None, schema_only=True)
     edge_color_variable_hint: Optional[str] = Setting(None, schema_only=True)
+
+    positions_hint: Optional[tuple[list[list[float]], str]] = \
+        Setting(None, schema_only=True)
 
     alpha_value = 255  # Override the setting from parent
 
@@ -630,9 +634,19 @@ class OWNxExplorer(OWDataProjectionWidget, ConcurrentWidgetMixin):
         if self.positions is None:
             set_actual_edges()
             set_edge_combos()
-            self.set_random_positions()
-            self.setup_plot()
-            self.relayout(True)
+
+            if (self.positions_hint is not None
+                and self.edges is not None
+                and len(self.positions_hint[0]) == self.number_of_nodes
+                and self.positions_hint[1] == self.edges_hash()
+            ):
+                self.positions = np.array(self.positions_hint[0])
+                self.setup_plot()
+            else:
+                self.set_random_positions()
+                self.setup_plot()
+                self.relayout(True)
+
         else:
             self.graph.update_point_props()
         self.update_marks()
@@ -788,6 +802,14 @@ class OWNxExplorer(OWDataProjectionWidget, ConcurrentWidgetMixin):
         self.graph.set_simplifications(
             self.graph.Simplifications.NoSimplifications)
         self.graph.update_coordinates()
+        self.positions_hint = (self.positions.tolist(), self.edges_hash())
+
+    def edges_hash(self):
+        h = hashlib.blake2b(digest_size=32)
+        h.update(self.edges.row.tobytes())
+        h.update(self.edges.col.tobytes())
+        h.update(self.edges.data.tobytes())
+        return h.hexdigest()
 
     @allot(0.02)
     def on_partial_result(self, positions):  # pylint: disable=arguments-renamed

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import Mock
 
 import numpy as np
+from AnyQt.QtTest import QSignalSpy
 
 from orangewidget.tests.utils import simulate
 
@@ -20,6 +21,8 @@ class TestOWNxExplorer(NetworkTest):
         self.davis_net = self._read_network("davis.net")
         self.davis_data = self._read_items("davis.tsv")
 
+        self.railway = self._read_network("railway.net")
+
     def test_minimum_size(self):
         # Disable this test from the base test class
         pass
@@ -30,6 +33,42 @@ class TestOWNxExplorerWithLayout(TestOWNxExplorer):
         net = Network([], [])
         # should not crash
         self.send_signal(self.widget.Inputs.network, net)
+
+    def test_positions_hint(self):
+        self.send_signal(self.widget.Inputs.network, self.davis_net)
+        self.wait_until_finished()
+
+        # Store positions
+        positions = self.widget.positions
+        self.assertIsNotNone(positions)
+        # Intermediate test: positions hint should be available after optimization finishes
+        self.assertIsNotNone(self.widget.positions_hint)
+
+        # Clear the network and check that positions are cleared as well
+        self.send_signal(self.widget.Inputs.network, None)
+        self.assertIsNone(self.widget.positions)
+
+        # Send the same network again and check that positions are the same as
+        # before. If hint was not used, positions would be different
+        self.send_signal(self.widget.Inputs.network, self.davis_net)
+        np.testing.assert_equal(self.widget.positions, positions)
+
+        # Send a different network and check that positions are different
+        # This must, basically, not crash
+        self.send_signal(self.widget.Inputs.network, self.railway)
+        self.wait_until_finished()
+
+        self.assertNotEqual(self.widget.positions.tolist(), positions.tolist())
+        positions = self.widget.positions
+
+        # Now change the edges and see that positions are updated
+        edges = self.railway.edges[0].edges.copy()
+        edges.indices[0] += 1
+        new_network = Network(self.railway.nodes, type(self.railway.edges[0])(edges))
+        self.send_signal(self.widget.Inputs.network, new_network)
+        self.wait_until_finished()
+
+        self.assertNotEqual(self.widget.positions.tolist(), positions.tolist())
 
 
 class TestOWNxEplorerWithoutLayout(TestOWNxExplorer):

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ if __name__ == '__main__':
         ext_modules=cythonize(EXTENSIONS),
         package_data=PACKAGE_DATA,
         data_files=DATA_FILES,
-        python_requires=">=3.8",
+        python_requires=">=3.11",
         setup_requires=SETUP_REQUIRES,
         cmdclass={
             'install': InstallMultilingualCommand,


### PR DESCRIPTION
##### Issue

Resolves #251.

##### Description of changes

Store the current positions of nodes as a hint, together with a hash of edge matrix. When the widget receives the same network, it uses the stored positions instead of rerunning the optimization.

Tests check that the hint is used when removing and re-adding a signal, while the actual intended benefit of this is to retrieve optimized positions from a stored workflow.

##### Includes
- [X] Code changes
- [X] Tests
