### PR TITLE
Network Explorer: Reset simplifications on cancel

### DIFF
--- a/orangecontrib/network/widgets/OWNxExplorer.py
+++ b/orangecontrib/network/widgets/OWNxExplorer.py
@@ -795,6 +795,8 @@ class OWNxExplorer(OWDataProjectionWidget, ConcurrentWidgetMixin):
     def cancel(self):
         self.set_buttons(running=False)
         super().cancel()
+        self.graph.set_simplifications(
+            self.graph.Simplifications.NoSimplifications)
 
     def on_done(self, positions):  # pylint: disable=arguments-renamed
         self.positions = positions

--- a/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
+++ b/orangecontrib/network/widgets/tests/test_OWNxExplorer.py
@@ -2,7 +2,6 @@ import unittest
 from unittest.mock import Mock
 
 import numpy as np
-from AnyQt.QtTest import QSignalSpy
 
 from orangewidget.tests.utils import simulate
 
@@ -69,6 +68,21 @@ class TestOWNxExplorerWithLayout(TestOWNxExplorer):
         self.wait_until_finished()
 
         self.assertNotEqual(self.widget.positions.tolist(), positions.tolist())
+
+    def test_edges_plotted(self):
+        self.assertIsNone(self.widget.graph.edge_curve)
+
+        self.send_signal(self.widget.Inputs.network, self.railway)
+        self.wait_until_finished()
+        self.assertIsNotNone(self.widget.graph.edge_curve)
+
+        self.send_signal(self.widget.Inputs.network, self.network)
+        self.assertIsNone(self.widget.graph.edge_curve)
+        self.widget.cancel()
+
+        self.send_signal(self.widget.Inputs.network, self.railway)
+        self.wait_until_finished()
+        self.assertIsNotNone(self.widget.graph.edge_curve)
 
 
 class TestOWNxEplorerWithoutLayout(TestOWNxExplorer):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Resolves #2, Closes #4 etc. -->
<!-- Or a short description, if the issue does not exist. -->
After canceling a computation and changing a dataset, the edges are not plotted.

##### Description of changes
Reset simplifications on cancel.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
