### PR TITLE
Pajek read/write: store and read tabular data as attributes

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -85,6 +85,17 @@ network/readwrite.py:
     class `PajekReader`:
         .net: false
         Pajek network file format: Format 'pajek'
+    def `read_edges`:
+        edge label: false
+    def `table_from_dicts`:
+        ?: false
+    def `dict_rows_from_table`:
+        def `esc`:
+            ' ': false
+            '"': false
+            \\": false
+        ' ': false
+        {esc(attr.name)} {esc(attr.str_val(value))}: false
     def `read_pajek`:
         def `check_has_vertices`:
             Vertices must be defined before edges or arcs: false
@@ -100,6 +111,7 @@ network/readwrite.py:
         *arcs: false
         *edgeslist: false
         *arcslist: false
+        node label: false
     def `write_pajek`:
         'This implementation of Pajek format does not support saving ': false
         networks with multiple edge types.: false
@@ -108,14 +120,19 @@ network/readwrite.py:
         *Network "{network.name}"\n: false
     def `_write_vertices`:
         *Vertices\t{network.number_of_nodes()}\n: false
-        {i:6} "{label}"\t: false
-        {' '.join(f'{c:.4f}' for c in coordinates)}\n: false
+        {''.join(f' {c:.4f}' for c in coords)}: false
+        0 0: false
+        {i:6} "{label}"\t{coordinates}: false
+        ' ellipse {attribute}': false
+        \n: false
     def `_write_edges`:
         *Arcs\n: false
         *Edges\n: false
         {row + 1:6} {col + 1:6}\n: false
         '{row + 1:6} {mat.indices[i] + 1:6} ': false
-        {mat.data[i]:.6f}\n: false
+        {mat.data[i]:.6f}: false
+        ' {edge_attributes[i]}': false
+        \n: false
     def `transform_data_to_orange_table`:
         x: false
         y: false
@@ -724,12 +741,20 @@ widgets/OWNxSave.py:
         class `Error`:
             Can't save network with multiple edge types: Omrežja z več vrstami povezav ni mogoče shraniti
         def `__init__`:
+            Node Labels: Oznake točk
             (None): (Brez)
-            'Node label: ': 'Oznaka točke: '
             label_variable: false
-            Choose the variables that will be used as a label: Izberite spremenljivke, ki bodo uporabljene kot oznaka
+            Choose the variable that will be used as a node label: Izberite spremenljivko, ki bo uporabljena kot oznaka točk.
+            append_node_data: false
+            Append other available node data: Dodaj ostale podatke o točkah
+            Edge Labels: Oznake povezav
+            edge_variable: false
+            Choose the variable that will be used as an edge label: Izberite spremenljivko, ki bo uporabljena kot oznaka povezav.
+            append_edge_data: false
+            Append other available edge data: Dodaj ostale podatke o povezavah
         def `set_network`:
             node_label: false
+            edge_label: false
         def `send_report`:
             Node labels: Oznake točk
             none: brez

--- a/orangecontrib/network/network/readwrite.py
+++ b/orangecontrib/network/network/readwrite.py
@@ -1,10 +1,17 @@
 import shlex
-from itertools import count, repeat
+from collections import defaultdict
+from itertools import count, repeat, chain
+from math import isnan
+from typing import Optional
 
 import numpy as np
 import scipy.sparse as sp
 
+from Orange.data import ContinuousVariable, is_discrete_values, \
+    DiscreteVariable, StringVariable, Domain, Table
 from Orange.data.io import FileFormatMeta
+from Orange.data.util import get_unique_names
+from Orange.misc.collections import natural_sorted
 from .base import Network, EdgeType
 
 __all__ = ("read_pajek", "write_pajek", "PajekReader")
@@ -23,32 +30,50 @@ class PajekReader(NetFileFormat):
         return read_pajek(filename)
 
     @staticmethod
-    def write(filename, network, labels=None):
-        return write_pajek(filename, network, labels)
+    def write(filename,
+              network,
+              labels: list[str] = None,
+              node_attributes: list[str] = None,
+              edge_attributes: list[str] = None):
+        return write_pajek(filename, network, labels, node_attributes, edge_attributes)
 
 
 def read_vertices(lines):
     coordinates = np.zeros((len(lines), 2))
     labels = np.full((len(lines)), None, dtype=object)
+    attrs = [{} for _ in lines]
     id_idx = {}
     for i, line in enumerate(lines):
-        node_id, *parts = shlex.split(line)[:4]
+        node_id, *parts = shlex.split(line)
         if not parts:
             label = str(node_id)
         else:
-            try:  # The format specification was never set in stone, it seems
-                label, x, y, *_ = parts + [None, None]
-                x, y = float(x), float(y)
-                coordinates[i, :2] = (x, y)
-            except (TypeError, ValueError):
-                if x is not None:
-                    label = line.strip().split(maxsplit=1)[1]
+            if len(parts) < 3:
+                label = parts[0]
+            else:
+                try:  # The format specification was never set in stone, it seems
+                    label, x, y, *shape = parts
+                    x, y = float(x), float(y)
+                    coordinates[i, :2] = (x, y)
+                    # skip "ellipse" and similar shape descriptors
+                    attrs[i] = dict(zip(shape[1::2], shape[2::2]))
+                except (TypeError, ValueError):
+                    if x is not None:
+                        label = line.strip().split(maxsplit=1)[1]
         id_idx[node_id] = i
         labels[i] = label
     if np.sum(np.abs(coordinates)) == 0:
         coordinates = None
-    return id_idx, labels, coordinates
+    return id_idx, labels, coordinates, attrs
 
+
+import math
+
+def is_number(s):
+    try:
+        return math.isfinite(float(s))
+    except ValueError:
+        return False
 
 def read_edges(id_idx, lines, nvertices):
     def fake_data(x, n):
@@ -56,25 +81,107 @@ def read_edges(id_idx, lines, nvertices):
         values.flags.writeable = False
         return values
 
-
+    values = [np.nan] * len(lines)
+    attrs = [{} for _ in lines]
     lines = sorted(
-        (id_idx[v1], id_idx[v2], value)
-        for v1, v2, value, *_ in (
-        (line.split(maxsplit=2) + [None])[:3] for line in lines))
-    v1s, v2s, values = zip(*lines)
+        (id_idx[v1], id_idx[v2], parts)
+        for v1, v2, *parts in (shlex.split(line) for line in lines))
+    for i, (v1, v2, parts) in enumerate(lines):
+        if len(parts) % 2 == 1:
+            values[i] = parts[0]
+            parts = parts[1:]
+        attrs[i] = dict(zip(parts[::2], parts[1::2]))
+    v1s, v2s, *_ = zip(*lines)
     try:
         values = np.array(values, dtype=float)
-        if np.all(np.isnan(values)):
+        no_values = np.all(np.isnan(values))
+        if no_values:
             values = fake_data(np.array(1.), len(values))
         elif values.size and np.all(values == values[0]):
             values = fake_data(values[0], len(values))
-        edge_data = None
+        else:
+            values[np.isnan(values)] = 1
+        labels = None
     except (TypeError, ValueError):
-        edge_data = np.array(values)
+        labels = values
         values = fake_data(np.array(1.), len(v1s))
+    if any(attrs):
+        edge_data = table_from_dicts(
+            attrs, label_name="edge label", label_values=labels)
+    else:
+        if labels is not None:
+            edge_data = np.array(labels, dtype=object)
+        elif not no_values:
+            edge_data = values
+        else:
+            edge_data = None
     return (sp.coo_matrix((values, (np.array(v1s), np.array(v2s))),
                           shape=(nvertices, nvertices)),
             edge_data)
+
+
+def table_from_dicts(dicts, label_name=None, label_values=None):
+    variables = defaultdict(set)
+    for dict_ in dicts:
+        for key, value in dict_.items():
+            variables[key].add(value)
+    if label_values is not None:
+        label_name = get_unique_names(list(variables), label_name)
+        variables[label_name] = set(label_values)
+    attrs = []
+    attr_indices = {}
+    metas = []
+    meta_indices = {}
+    for key, values in variables.items():
+        if all(value == "?" or value == None for value in values):
+            # Ignore the variable
+            continue
+        if all(value == "?" or value == None or is_number(value) for value in values):
+            attr_indices[key] = len(attrs)
+            attrs.append(ContinuousVariable(key))
+        elif is_discrete_values(values):
+            attr_indices[key] = len(attrs)
+            attrs.append(DiscreteVariable(key, values=natural_sorted(values)))
+        else:
+            meta_indices[key] = len(metas)
+            metas.append(StringVariable(key))
+    x = np.full((len(dicts), len(attrs)), np.nan)
+    m = np.full((len(dicts), len(metas)), "", dtype=object)
+    for i, dict_ in enumerate(dicts):
+        for key, value in chain(dict_.items(),
+                                ((label_name, label_values[i]), ) if label_values is not None else ()):
+            index = attr_indices.get(key)
+            if index is not None:
+                if value == "?":
+                    continue
+                elif attrs[index].is_continuous:
+                    x[i, attr_indices[key]] = float(value)
+                else:
+                    x[i, attr_indices[key]] = attrs[index].to_val(value)
+            elif key in meta_indices:
+                m[i, meta_indices[key]] = value
+            # else all values were "?" or None, so we ignored the variable entirely
+    domain = Domain(attrs, metas=metas)
+    return Table.from_numpy(domain, x, metas=m)
+
+
+def dict_rows_from_table(data, exclude=None):
+    def esc(s):
+        if " " in s or '"' in s:
+            return '"' + s.replace('"', '\\"') + '"'
+        else:
+            return s
+
+    all_attrs = [attr
+                 for attr in chain(data.domain.attributes, data.domain.metas)
+                 if attr.name != exclude]
+    return [
+        " ".join(
+            f"{esc(attr.name)} {esc(attr.str_val(value))}"
+            for value, attr in ((data[i, attr], attr) for attr in all_attrs)
+            if (value != "" if isinstance(value, str) else not isnan(value))
+        )
+        for i, inst in enumerate(data)]
 
 
 def read_edges_list(id_idx, lines, nvertices):
@@ -107,7 +214,7 @@ def read_pajek(path):
                    if line[0] == "*"]
     network_name = None
     edges = []
-    labels = coordinates = None
+    labels = coordinates = attributes = None
     in_first_mode = None
     for (start_line, part_desc), (end_line, *_) \
             in zip(part_starts, part_starts[1:] + [(len(lines), "")]):
@@ -126,7 +233,7 @@ def read_pajek(path):
                 raise ValueError(
                     "Pajek files with multiple set of vertices are not "
                     "supported")
-            id_idx, labels, coordinates = read_vertices(line_part)
+            id_idx, labels, coordinates, attributes = read_vertices(line_part)
             part_args = part_args.split()
             if len(part_args) > 1:
                 in_first_mode = int(part_args[1])
@@ -142,52 +249,76 @@ def read_pajek(path):
                 EdgeType[part_type=="*arcslist"](
                     read_edges_list(id_idx, line_part, len(labels)),
                     name=part_args.strip() or part_type[1:]))
+    if np.any(attributes):
+        labels = table_from_dicts(attributes, label_name="node label", label_values=labels)
     network = Network(labels, edges, network_name or "", coordinates)
     if in_first_mode is not None:
         network.in_first_mode = in_first_mode
     return network
 
 
-def write_pajek(path, network, labels=None):
+def write_pajek(path,
+                network,
+                labels: Optional[list[str]] = None,
+                node_attributes: Optional[list[str]] = None,
+                edge_attributes: Optional[list[str]] = None):
     if len(network.edges) > 1:
         raise TypeError(
             "This implementation of Pajek format does not support saving "
             "networks with multiple edge types.")
     f = open(path, "wt", encoding="utf-8") if isinstance(path, str) else path
     f.write(f'*Network "{network.name}"\n')
-    _write_vertices(f, network, labels)
+    _write_vertices(f, network, labels, node_attributes)
     if network.edges:
-        _write_edges(f, network)
+        _write_edges(f, network, edge_attributes)
     if f is not path:
         f.close()
 
 
-def _write_vertices(f, network, labels=None):
+def _write_vertices(f, network,
+                    labels: Optional[list[str]] = None,
+                    node_attributes: Optional[list[str]] = None):
     if labels is None:
         labels = network.nodes
 
     f.write(f"*Vertices\t{network.number_of_nodes()}\n")
     if network.coordinates is not None:
-        coords = network.coordinates
+        coords = (f"{''.join(f' {c:.4f}' for c in coords)}"
+                  for coords in network.coordinates)
     else:
-        coords = repeat(())
-    for i, label, coordinates in zip(count(start=1), labels, coords):
-        f.write(f'{i:6} "{label}"\t' +
-                f"{' '.join(f'{c:.4f}' for c in coordinates)}\n")
+        coords = ()
+    if node_attributes is None:
+        node_attributes = ()
+    for i, label, coordinates, attribute \
+            in zip(count(start=1),
+                   labels,
+                   chain(coords, repeat("0 0" if node_attributes else "")),
+                   chain(node_attributes, repeat(()))):
+        f.write(f'{i:6} "{label}"\t{coordinates}'
+                + (f" ellipse {attribute}" if attribute else "")
+                + "\n"
+                )
 
 
-def _write_edges(f, network):
+def _write_edges(f, network, edge_attributes: Optional[list[str]] = None):
     edges = network.edges[0]
     f.write("*Arcs\n" if edges.directed else "*Edges\n")
     mat = edges.edges
-    if np.all(mat.data == 1):
+    if np.all(mat.data == 1) and edge_attributes is None:
         for row, rb, re in zip(count(), mat.indptr, mat.indptr[1:]):
             f.write("".join(f"{row + 1:6} {col + 1:6}\n"
                             for col in mat.indices[rb:re]))
-    else:
-        for row, rb, re in zip(count(), mat.indptr, mat.indptr[1:]):
-            f.write("".join(f"{row + 1:6} {mat.indices[i] + 1:6} "
-                            f"{mat.data[i]:.6f}\n" for i in range(rb, re)))
+        return
+    if edge_attributes is None:
+        edge_attributes = [()] * len(mat.data)
+    for row, rb, re in zip(count(), mat.indptr, mat.indptr[1:]):
+        f.write("".join(f"{row + 1:6} {mat.indices[i] + 1:6} "
+                        f"{mat.data[i]:.6f}" +
+                        (f" {edge_attributes[i]}"
+                         if i < len(edge_attributes) and edge_attributes[i]
+                         else "")
+                        + "\n"
+                        for i in range(rb, re)))
 
 
 # TODO: doesn't belong here if this module is meant as independent from Orange

--- a/orangecontrib/network/network/tests/test_readwrite.py
+++ b/orangecontrib/network/network/tests/test_readwrite.py
@@ -5,7 +5,10 @@ from tempfile import NamedTemporaryFile
 
 import numpy as np
 
+from Orange.data import ContinuousVariable, DiscreteVariable, StringVariable
 from orangecontrib.network.network import readwrite
+from orangecontrib.network.network.readwrite import dict_rows_from_table, \
+    table_from_dicts
 
 
 def _fullpath(name):
@@ -41,6 +44,55 @@ class TestReadPajek(unittest.TestCase):
         self.assertEqual(
             list(net.edges[0].edge_data),
             ['near', 'far', 'not near, not far', 'huh?'])
+
+    def test_data(self):
+        net = readwrite.read_pajek(_fullpathtest("towns-2.net"))
+        self.do_test(net)
+
+    def do_test(self, net):
+        self.assertEqual(net.number_of_nodes(), 5)
+        self.assertIsInstance(net.nodes.domain["population"], ContinuousVariable)
+        self.assertIsInstance(net.nodes.domain["capital"], DiscreteVariable)
+        self.assertIsInstance(net.nodes.domain["region"], StringVariable)
+        self.assertIsInstance(net.nodes.domain["node label"], StringVariable)
+        np.testing.assert_equal(
+            net.nodes.get_column("node label"),
+            ["Ljubljana", "Kranj", "Maribor", "Novo mesto", "Celje"])
+        np.testing.assert_equal(
+            net.nodes.get_column("population"),
+            [300000, 38000, 110000, np.nan, np.nan])
+        np.testing.assert_equal(
+            net.nodes.get_column("capital"),
+            [1, np.nan, np.nan, 0, np.nan])
+        np.testing.assert_equal(
+            net.nodes.get_column("region"),
+            ["central", "gorenjska", "štajerska", "dolenjska", ""])
+
+        data = net.edges[0].edge_data
+        self.assertIsInstance(data.domain["distance"], ContinuousVariable)
+        self.assertIsInstance(data.domain["qdist"], StringVariable)
+        self.assertIsInstance(data.domain["relations"], DiscreteVariable)
+
+        np.testing.assert_equal(
+            data.get_column("distance"), [30, 130, 74, np.nan])
+        np.testing.assert_equal(
+            data.get_column("qdist"), ["near", "far", "not near, not far", ""])
+        np.testing.assert_equal(
+            data.get_column("relations"), [np.nan, 0, np.nan, np.nan])
+
+    def test_write_data(self):
+        net = readwrite.read_pajek(_fullpathtest("towns-2.net"))
+        with NamedTemporaryFile("wt", suffix=".net", delete=False, encoding="utf-8") as f:
+            try:
+                readwrite.write_pajek(
+                    f, net, net.nodes.get_column("node label"),
+                    dict_rows_from_table(net.nodes, exclude="node label"),
+                    dict_rows_from_table(net.edges[0].edge_data, exclude="edge label"))
+                f.close()
+                net2 = readwrite.read_pajek(f.name)
+                self.do_test(net2)
+            finally:
+                os.remove(f.name)
 
     def test_write_pajek(self):
         net = readwrite.read_pajek(_fullpath("../networks/leu_by_genesets.net"))
@@ -88,6 +140,57 @@ class TestReadPajek(unittest.TestCase):
         self.assertTrue(net.edges[0].directed)
         for x, y in neighs:
             np.testing.assert_equal(net.outgoing(x - 1), np.array(y) - 1)
+
+
+class TestUtils(unittest.TestCase):
+    def test_is_number(self):
+        self.assertTrue(readwrite.is_number("1"))
+        self.assertTrue(readwrite.is_number("1.5"))
+        self.assertTrue(readwrite.is_number("-1.5"))
+        self.assertFalse(readwrite.is_number("abc"))
+        self.assertFalse(readwrite.is_number("1,5"))
+        self.assertFalse(readwrite.is_number("nan"))
+
+    def test_dicts_from_table(self):
+        from Orange.data import Table, Domain
+        domain = Domain([ContinuousVariable("a a"),
+                         DiscreteVariable("b", ("red", "light green"))],
+                        metas=[StringVariable("c\"")])
+        table = Table.from_list(domain, [[1, 0, ""],
+                                         [2, np.nan, "y"],
+                                         [np.nan, 1, "z"],
+                                         [np.nan, np.nan, ""]])
+        rows = dict_rows_from_table(table)
+        self.assertEqual(
+            rows,
+            ['"a a" 1 b red', '"a a" 2 "c\\"" y', 'b "light green" "c\\"" z', ""])
+
+    def test_table_from_dicts(self):
+        dicts = [{"a": 1, "b": "red", "c": "x"},
+                 {"a": 2, "c": "y"},
+                 {"b": "green", "c": "z"},
+                 {}]
+        table = table_from_dicts(dicts)
+        np.testing.assert_equal(
+            table.X,
+            [[1, 1],
+             [2, np.nan],
+             [np.nan, 0],
+             [np.nan, np.nan]])
+        np.testing.assert_equal(table.metas, [["x"], ["y"], ["z"], [""]])
+
+        table = table_from_dicts(
+            dicts, label_name="a", label_values=["foo", "bar", "baz", "qux"])
+        np.testing.assert_equal(
+            table.X,
+            [[1, 1],
+             [2, np.nan],
+             [np.nan, 0],
+             [np.nan, np.nan]])
+        np.testing.assert_equal(
+            table.metas,
+            [["x", "foo"], ["y", "bar"], ["z", "baz"], ["", "qux"]])
+        self.assertEqual(table.domain.metas[1].name, "a (1)")
 
 
 if __name__ == "__main__":

--- a/orangecontrib/network/network/tests/towns-2.net
+++ b/orangecontrib/network/network/tests/towns-2.net
@@ -1,0 +1,13 @@
+*Network "Test"
+*Description "Slovenian towns"
+*Vertices
+1 "Ljubljana" 0 0 ellipse population 300000 capital yes region central
+2 "Kranj" 0 0 ellipse population 38000 region gorenjska
+3 "Maribor" 0 0 ellipse population 110000 region štajerska
+4 "Novo mesto" 0 0 ellipse capital no region dolenjska
+5 "Celje"
+*Edges
+1	2	2 distance 30 qdist "near"
+3	4   3.14
+1	3	relations "strained :)" distance 130 qdist far
+1	4	distance 74 qdist "not near, not far"

--- a/orangecontrib/network/network/tests/towns.net
+++ b/orangecontrib/network/network/tests/towns.net
@@ -9,4 +9,4 @@
 1	2	near
 3	4	huh?
 1	3	far
-1	4	not near, not far
+1	4	"not near, not far"

--- a/orangecontrib/network/widgets/OWNxFile.py
+++ b/orangecontrib/network/widgets/OWNxFile.py
@@ -410,9 +410,19 @@ class OWNxFile(OWWidget):
             data = None
 
         if data is None:
-            return self._label_to_tabel()
+            if isinstance(self.original_nodes, Table):
+                return self.original_nodes
+            else:
+                return self._label_to_tabel()
         elif self.label_variable is None:
-            return self._combined_data(data)
+            if isinstance(self.original_nodes, Table):
+                # We could try to merge the two tables (original_nodes
+                # from the network file and data from an extra file),
+                # but we should probably let the explicit data override that
+                # from the network file, hence we return `data`.
+                return data
+            else:
+                return self._combined_data(data)
         else:
             return self._data_by_labels(data)
 

--- a/orangecontrib/network/widgets/OWNxSave.py
+++ b/orangecontrib/network/widgets/OWNxSave.py
@@ -1,13 +1,14 @@
 from Orange.data import StringVariable, Table
 from Orange.widgets import gui
-from Orange.widgets.settings import DomainContextHandler, ContextSetting
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.widget import Input, Msg
 
 from Orange.widgets.data.owsave import OWSaveBase
 from orangecontrib.network.network import readwrite
 from orangecontrib.network.network.base import Network
-from orangecontrib.network.network.readwrite import PajekReader
+from orangecontrib.network.network.readwrite import PajekReader, \
+    dict_rows_from_table
+from orangewidget.settings import Setting
 from orangewidget.utils.widgetpreview import WidgetPreview
 
 
@@ -26,29 +27,62 @@ class OWNxSave(OWSaveBase):
     class Error(OWSaveBase.Error):
         multiple_edge_types = Msg("Can't save network with multiple edge types")
 
-    settingsHandler = DomainContextHandler()
-    label_variable = ContextSetting(None)
+    label_variable_hint = Setting(None)
+    edge_variable_hint = Setting(None)
+    append_node_data = Setting(False)
+    append_edge_data = Setting(False)
 
     def __init__(self):
         super().__init__(2)
+        self.label_variable = None
+        self.edge_variable = None
 
+        self.grid.setSpacing(24)
+
+        box = gui.vBox(None, "Node Labels")
         self.label_model = DomainModel(
             placeholder="(None)", valid_types=(StringVariable, ))
-        box = gui.hBox(None)
-        gui.widgetLabel(box, "Node label: ")
         gui.comboBox(
             box, self, "label_variable",
-            tooltip="Choose the variables that will be used as a label",
-            model=self.label_model),
-
+            tooltip="Choose the variable that will be used as a node label",
+            model=self.label_model,
+            callback=self.update_label_hint)
+        gui.checkBox(
+            box, self, "append_node_data",
+            "Append other available node data"
+        )
         self.grid.addWidget(box, 0, 0, 1, 2)
-        self.grid.setRowMinimumHeight(1, 8)
+
+        box = gui.vBox(None, "Edge Labels")
+        self.edge_model = DomainModel(
+            placeholder="(None)", valid_types=(StringVariable, ))
+        gui.comboBox(
+            box, self, "edge_variable",
+            tooltip="Choose the variable that will be used as an edge label",
+            model=self.edge_model,
+            callback=self.update_edge_hint)
+        gui.checkBox(
+            box, self, "append_edge_data",
+            "Append other available edge data"
+        )
+        self.grid.addWidget(box, 1, 0, 1, 2)
+
         self.adjustSize()
+
+    def update_label_hint(self):
+        if self.label_variable is not None:
+            self.label_variable_hint = self.label_variable.name
+        else:
+            self.label_variable_hint = None
+
+    def update_edge_hint(self):
+        if self.edge_variable is not None:
+            self.edge_variable_hint = self.edge_variable.name
+        else:
+            self.edge_variable_hint = None
 
     @Inputs.network
     def set_network(self, network):
-        self.closeContext()
-
         self.data = network
         if network is None:
             return
@@ -66,15 +100,33 @@ class OWNxSave(OWSaveBase):
                 if attr.name == "node_label":
                     self.label_variable = attr
                     break
-            self.openContext(domain)
+            if self.label_variable_hint in domain and \
+                    (attr := domain[self.label_variable_hint]) in self.label_model:
+                self.label_variable = domain[self.label_variable_hint]
         else:
             self.label_model.set_domain(None)
             self.label_variable = None
             self.controls.label_variable.setEnabled(False)
 
+        if isinstance(network.edges[0].edge_data, Table):
+            self.controls.edge_variable.setEnabled(True)
+            domain = network.edges.domain
+            self.edge_model.set_domain(domain)
+            for attr in domain.metas:
+                if attr.name == "edge_label":
+                    self.edge_variable = attr
+                    break
+            if self.edge_variable_hint in domain and \
+                    (attr := domain[self.edge_variable]) in self.edge_model:
+                self.edge_variable = attr
+        else:
+            self.edge_model.set_domain(None)
+            self.edge_variable = None
+            self.controls.edge_variable.setEnabled(False)
+
         self.on_new_input()
 
-    def save_file(self):
+    def do_save(self):
         if not self.filename:
             self.save_file_as()
             return
@@ -88,7 +140,15 @@ class OWNxSave(OWSaveBase):
                 labels = net.nodes.get_column(self.label_variable)
             else:
                 labels = range(1, net.number_of_nodes() + 1)
-            self.writer.write(self.filename, net, labels)
+            if self.append_node_data and isinstance(data := net.nodes, Table):
+                label_data = dict_rows_from_table(data, self.label_variable)
+            else:
+                label_data = None
+            if self.append_edge_data and isinstance(data := net.edges[0].edge_data, Table):
+                edge_data = dict_rows_from_table(data, self.edge_variable)
+            else:
+                edge_data = None
+            self.writer.write(self.filename, net, labels, label_data, edge_data)
         except IOError as err_value:
             self.Error.general_error(str(err_value))
 


### PR DESCRIPTION
##### Issue

Fixes #286. Fixes #275.

##### Description of changes

When saving, add data about nodes and edges. For nodes, this data is saved in the same format as in NetworkX, which is a hack of what's in Pajek. For edges, the format is the same, though unsupported by NetworkX (AFAIK).

When reading -- read the data save in this way.

The format is a mess: it allows (but doesn't require) node coordinates. Edges may have a numeric weight or a non-numeric label, but not both, to which we now add NetworkX-like key-value pairs, and so forth.

Tests for existing mess are lacking, and the new tests might not cover all possible combinations.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
