### PR TITLE
Embeddings: Change date for checking whether gensim supports py 3.14

### DIFF
--- a/orangecontrib/network/network/tests/test_embeddings.py
+++ b/orangecontrib/network/network/tests/test_embeddings.py
@@ -18,7 +18,7 @@ class TestEmbeddings(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if gensim is None:
-            if datetime.date.today() < datetime.date(2026, 6, 1):
+            if datetime.date.today() < datetime.date(2026, 10, 1):
                 raise unittest.SkipTest(
                     "gensim library is required to run these tests.")
             else:


### PR DESCRIPTION
Gensim still doesn't support Python 3.14. Move the date in the tests that remind us to check for it.
